### PR TITLE
Speed up the ref clip and set a higher exaggeration value

### DIFF
--- a/gradio_tts_app.py
+++ b/gradio_tts_app.py
@@ -49,7 +49,7 @@ with gr.Blocks() as demo:
             with gr.Accordion("More options", open=False):
                 seed_num = gr.Number(value=0, label="Random seed (0 for random)")
                 temp = gr.Slider(0.05, 5, step=.05, label="temperature", value=.8)
-                pace = gr.Slider(0.6, 2.0, step=.05, label="pace", value=1.25)
+                pace = gr.Slider(1.0, 2.0, step=.05, label="pace", value=1.25)
 
             run_btn = gr.Button("Generate", variant="primary")
 

--- a/src/chatterbox/tts.py
+++ b/src/chatterbox/tts.py
@@ -14,7 +14,7 @@ from .models.s3gen import S3GEN_SR, S3Gen
 from .models.tokenizers import EnTokenizer
 from .models.voice_encoder import VoiceEncoder
 from .models.t3.modules.cond_enc import T3Cond
-from .utils import adjust_pace, trim_silence
+from .utils import speedup, trim_silence
 
 
 REPO_ID = "ResembleAI/chatterbox"
@@ -187,11 +187,12 @@ class ChatterboxTTS:
         s3gen_ref_dict = self.s3gen.embed_ref(s3gen_ref_wav, S3GEN_SR, device=self.device)
 
         # Slightly speed up the ref clip for user preference
-        ref_16k_wav = adjust_pace(
-            ref_16k_wav,
-            S3_SR,
-            target_speed=pace,
-        )
+        if pace > 1:
+            ref_16k_wav = speedup(
+                ref_16k_wav,
+                S3_SR,
+                target_speed=pace,
+            )
 
         # Speech cond prompt tokens
         if plen := self.t3.hp.speech_cond_prompt_len:

--- a/src/chatterbox/utils.py
+++ b/src/chatterbox/utils.py
@@ -33,7 +33,10 @@ def audseg2np(audio_segment):
 
 
 def change_audio_pace(audio_seg, speed=1.0):
-    """Change pace using Pydub speedup (alters pitch as well)."""
+    """Change pace using Pydub speedup (alters pitch as well).
+    NOTE: there's a bug in `pydub`: speed can't be 0.5 (ZeroDivisionError) or 1 (the clip becomes super tiny).
+    """
+
     return audio_seg.speedup(speed)
 
 
@@ -42,7 +45,9 @@ def resample_audio(audio_seg, new_sr):
     return audio_seg.set_frame_rate(new_sr)
 
 
-def adjust_pace(wav_np, orig_sr, target_sr=None, target_speed=1):
+def speedup(wav_np, orig_sr, target_sr=None, target_speed=1.2):
+    assert 1 < target_speed, "Target speed must be greater than 0."
+
     audio = np2audseg(wav_np, orig_sr)
 
     paced_audio = change_audio_pace(audio, speed=target_speed)


### PR DESCRIPTION
# Changelog
- Default: exaggeration=0.7, pace=1.2
- Added `silero-vad` for VAD and `pydub` for speeding up the input.