### PR TITLE
fix: update numpy patch version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "resemble-ai", email = "engineering@resemble.ai"}
 ]
 dependencies = [
-    "numpy==1.26.0",
+    "numpy==1.26.4",
     "resampy==0.4.3",
     "librosa==0.10.0",
     "s3tokenizer",


### PR DESCRIPTION
Resolving dependency conflicts:

```bash
% pip install chatterbox-tts
Collecting chatterbox-tts
  Using cached chatterbox_tts-0.1.1-py3-none-any.whl.metadata (5.9 kB)
INFO: pip is looking at multiple versions of chatterbox-tts to determine which version is compatible with other requirements. This could take a while.
  Using cached chatterbox_tts-0.1.0-py3-none-any.whl.metadata (5.9 kB)
ERROR: Cannot install chatterbox-tts==0.1.0 and chatterbox-tts==0.1.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    chatterbox-tts 0.1.1 depends on numpy==1.26.0
    chatterbox-tts 0.1.0 depends on numpy==1.26.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict
```