### PR TITLE
'device in [cpu,mps] yet assigning 'cpu' erros on 'mps' device

### DIFF
--- a/src/chatterbox/tts.py
+++ b/src/chatterbox/tts.py
@@ -130,8 +130,10 @@ class ChatterboxTTS:
         ckpt_dir = Path(ckpt_dir)
 
         # Always load to CPU first for non-CUDA devices to handle CUDA-saved models
-        if device in ["cpu", "mps"]:
+        if device == "cpu":
             map_location = torch.device('cpu')
+        elif device == "mps":
+            map_location = torch.device('mps')
         else:
             map_location = None
 


### PR DESCRIPTION
## Context: When trying to run `example_tts.py` based runnable code, kept getting following error. 

### `RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.`

###  Inspite following `example_tts.py`  following device check kept failing :

```
if torch.cuda.is_available():
    device = "cuda"
elif torch.backends.mps.is_available():
    device = "mps"
else:
    device = "cpu"
```

### Hence torch.load calls need to be guarded by `map_location=device` :

### Therefore modified :

> `/Users/zorawarpurohit/Documents/code_bases/chatterbox/env/lib/python3.12/site-packages/chatterbox/tts.py , line 163,`

From : `t3_state = torch.load(ckpt_dir / 't3_cfg.pt')` ❌

To : `t3_state = torch.load(ckpt_dir / 't3_cfg.pt', map_location=device)` ✅

> In fact all torch.load in tts.py needed to be refactored. 