### PR TITLE
Migrate to logging.warning

### DIFF
--- a/src/chatterbox/models/t3/inference/alignment_stream_analyzer.py
+++ b/src/chatterbox/models/t3/inference/alignment_stream_analyzer.py
@@ -141,7 +141,7 @@ class AlignmentStreamAnalyzer:
         # If a bad ending is detected, force emit EOS by modifying logits
         # NOTE: this means logits may be inconsistent with latents!
         if long_tail or repetition:
-            logger.warn(f"forcing EOS token, {long_tail=}, {repetition=}")
+            logger.warning(f"forcing EOS token, {long_tail=}, {repetition=}")
             # (±2**15 is safe for all dtypes >= 16bit)
             logits = -(2**15) * torch.ones_like(logits)
             logits[..., self.eos_idx] = 2**15


### PR DESCRIPTION
## PR Summary
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
