### PR TITLE
Fix: update python versions be 3.9 and greater to avoid pytorch dependency issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "chatterbox-tts"
 version = "0.1.2"
 description = "Chatterbox: Open Source TTS and Voice Conversion by Resemble AI"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 authors = [
     {name = "resemble-ai", email = "engineering@resemble.ai"}


### PR DESCRIPTION
Python 3.8 results in pytorch version incompatibility issue
```
$ uv run --python 3.8 --with=git+https://github.com/resemble-ai/chatterbox https://raw.githubusercontent.com/resemble-ai/chatterbox/refs/heads/master/example_tts.py
  × No solution found when resolving `--with` dependencies:
  ╰─▶ Because torch==2.6.0 has no wheels with a matching Python implementation tag (e.g., `cp38`) and chatterbox-tts==0.1.2 depends on torch==2.6.0,
      we can conclude that chatterbox-tts==0.1.2 cannot be used.
      And because only chatterbox-tts==0.1.2 is available and you require chatterbox-tts, we can conclude that your requirements are unsatisfiable.

      hint: You require CPython 3.8 (`cp38`), but we only found wheels for `torch` (v2.6.0) with the following Python implementation tags: `cp39`,
      `cp310`, `cp311`, `cp312`, `cp313`
```