### PR TITLE
feat: Implement token-level timestamp generation for TTS

### DIFF
--- a/example_tts.py
+++ b/example_tts.py
@@ -15,8 +15,19 @@ print(f"Using device: {device}")
 model = ChatterboxTTS.from_pretrained(device=device)
 
 text = "Ezreal and Jinx teamed up with Ahri, Yasuo, and Teemo to take down the enemy's Nexus in an epic late-game pentakill."
-wav = model.generate(text)
-ta.save("test-1.wav", wav, model.sr)
+result = model.generate(text)
+audio_tensor = result['audio_tensor']
+timestamps = result['timestamps']
+ta.save("test-1.wav", audio_tensor, model.sr)
+
+print("\nTimestamps for the first example:")
+if timestamps:
+    for i, ts_entry in enumerate(timestamps[:5]): # Print first 5 timestamps
+        print(f"  Token {i+1}: '{ts_entry['token_text']}', Start: {ts_entry['start_time']:.2f}s, End: {ts_entry['end_time']:.2f}s")
+    if len(timestamps) > 5:
+        print(f"  ... and {len(timestamps) - 5} more timestamp entries.")
+else:
+    print("  No timestamps generated.")
 
 # If you want to synthesize with a different voice, specify the audio prompt
 AUDIO_PROMPT_PATH = "YOUR_FILE.wav"


### PR DESCRIPTION
This commit introduces the capability to generate token-level timestamps for the text-to-speech output.

Key changes include:

1.  Enhanced `T3.inference` to leverage the existing `AlignmentStreamAnalyzer` more effectively. It now collects frame-by-frame alignment data (text token index vs. audio frame index) and returns this history.

2.  Modified `ChatterboxTTS.generate` to: a. Receive the raw alignment history from `T3.inference`. b. Process this history to calculate precise start and end times for each token. The calculation assumes a token rate of 25Hz (0.04s per frame). c. Filter out special SOT/EOT tokens from the final timestamp list. d. Adjust the end time of the last token to match the exact duration of the synthesized audio. e. Return a dictionary containing both the audio tensor and the list of token timestamps (each entry being `{'token_text': str, 'start_time': float, 'end_time': float}`).

3.  Updated `example_tts.py` to demonstrate how to retrieve and use these timestamps.

This feature allows you to know the exact start and end time of each token in the generated audio file, which can be useful for various applications like subtitle generation, animation synchronization, or further speech analysis.