### PR TITLE
Enable usage of Min_P Sampler, modify other sampler settings

### DIFF
--- a/gradio_tts_app.py
+++ b/gradio_tts_app.py
@@ -21,7 +21,7 @@ def load_model():
     return model
 
 
-def generate(model, text, audio_prompt_path, exaggeration, temperature, seed_num, cfgw):
+def generate(model, text, audio_prompt_path, exaggeration, temperature, seed_num, cfgw, min_p, top_p, repetition_penalty):
     if model is None:
         model = ChatterboxTTS.from_pretrained(DEVICE)
 
@@ -34,6 +34,9 @@ def generate(model, text, audio_prompt_path, exaggeration, temperature, seed_num
         exaggeration=exaggeration,
         temperature=temperature,
         cfg_weight=cfgw,
+        min_p=min_p,
+        top_p=top_p,
+        repetition_penalty=repetition_penalty,
     )
     return (model.sr, wav.squeeze(0).numpy())
 
@@ -55,6 +58,9 @@ with gr.Blocks() as demo:
             with gr.Accordion("More options", open=False):
                 seed_num = gr.Number(value=0, label="Random seed (0 for random)")
                 temp = gr.Slider(0.05, 5, step=.05, label="temperature", value=.8)
+                min_p = gr.Slider(0.00, 1.00, step=0.01, label="min_p || Newer Sampler. Recommend 0.02 > 0.1. Handles Higher Temperatures better. 0.00 Disables", value=0.05)
+                top_p = gr.Slider(0.00, 1.00, step=0.01, label="top_p || Original Sampler. 1.0 Disables(recommended). Original 0.8", value=1.00)
+                repetition_penalty = gr.Slider(1.00, 2.00, step=0.1, label="repetition_penalty", value=1.2)
 
             run_btn = gr.Button("Generate", variant="primary")
 
@@ -73,6 +79,9 @@ with gr.Blocks() as demo:
             temp,
             seed_num,
             cfg_weight,
+            min_p,
+            top_p,
+            repetition_penalty,
         ],
         outputs=audio_output,
     )

--- a/src/chatterbox/models/t3/t3.py
+++ b/src/chatterbox/models/t3/t3.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn, Tensor
 from transformers import LlamaModel, LlamaConfig
-from transformers.generation.logits_process import TopPLogitsWarper, RepetitionPenaltyLogitsProcessor
+from transformers.generation.logits_process import MinPLogitsWarper, RepetitionPenaltyLogitsProcessor, TopPLogitsWarper
 
 from .modules.learned_pos_emb import LearnedPositionEmbeddings
 
@@ -217,9 +217,10 @@ class T3(nn.Module):
         stop_on_eos=True,
         do_sample=True,
         temperature=0.8,
-        top_p=0.8,
+        min_p=0.05,
+        top_p=1.00,
         length_penalty=1.0,
-        repetition_penalty=2.0,
+        repetition_penalty=1.2,
         cfg_weight=0,
     ):
         """
@@ -271,7 +272,7 @@ class T3(nn.Module):
         #     max_new_tokens=max_new_tokens or self.hp.max_speech_tokens,
         #     num_return_sequences=num_return_sequences,
         #     temperature=temperature,
-        #     top_p=top_p,
+        #     min_p=min_p,
         #     length_penalty=length_penalty,
         #     repetition_penalty=repetition_penalty,
         #     do_sample=do_sample,
@@ -298,8 +299,9 @@ class T3(nn.Module):
         predicted = []  # To store the predicted tokens
 
         # Instantiate the logits processors.
+        min_p_warper = MinPLogitsWarper(min_p=min_p)
         top_p_warper = TopPLogitsWarper(top_p=top_p)
-        repetition_penalty_processor = RepetitionPenaltyLogitsProcessor(penalty=repetition_penalty)
+        repetition_penalty_processor = RepetitionPenaltyLogitsProcessor(penalty=float(repetition_penalty))
 
         # ---- Initial Forward Pass (no kv_cache yet) ----
         output = self.patched_model(
@@ -331,6 +333,7 @@ class T3(nn.Module):
 
             # Apply repetition penalty and top‑p filtering.
             logits = repetition_penalty_processor(generated_ids, logits)
+            logits = min_p_warper(None, logits)
             logits = top_p_warper(None, logits)
 
             # Convert logits to probabilities and sample the next token.

--- a/src/chatterbox/tts.py
+++ b/src/chatterbox/tts.py
@@ -208,6 +208,9 @@ class ChatterboxTTS:
     def generate(
         self,
         text,
+        repetition_penalty=1.2,
+        min_p=0.05,
+        top_p=1.0,
         audio_prompt_path=None,
         exaggeration=0.5,
         cfg_weight=0.5,
@@ -246,6 +249,9 @@ class ChatterboxTTS:
                 max_new_tokens=1000,  # TODO: use the value in config
                 temperature=temperature,
                 cfg_weight=cfg_weight,
+                repetition_penalty=repetition_penalty,
+                min_p=min_p,
+                top_p=top_p,
             )
             # Extract only the conditional batch.
             speech_tokens = speech_tokens[0]


### PR DESCRIPTION
Fixes https://github.com/resemble-ai/chatterbox/issues/154
This commit enables the use of min_p sampler, as well as giving the gradio app sliders to configure  top_p, min_p and repetition_penalty

Changed the defaults to min_p=0.05, rep_pen=1.2, top_p=1.0

min_p=0.00 - disables
top_p=1.00 - disables