### PR TITLE
Nitpick: Define TTS acronym

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 _Made with ♥️ by <a href="https://resemble.ai" target="_blank"><img width="100" alt="resemble-logo-horizontal" src="https://github.com/user-attachments/assets/35cf756b-3506-4943-9c72-c05ddfa4e525" /></a>
 
-We're excited to introduce Chatterbox, [Resemble AI's](https://resemble.ai) first production-grade open source text-to-speech (TTS) model. Licensed under MIT, Chatterbox has been benchmarked against leading closed-source systems like ElevenLabs, and is consistently preferred in side-by-side evaluations.
+We're excited to introduce Chatterbox, [Resemble AI's](https://resemble.ai) first production-grade open-source text-to-speech (TTS) model. Licensed under MIT, Chatterbox has been benchmarked against leading closed-source systems like ElevenLabs, and is consistently preferred in side-by-side evaluations.
 
 Whether you're working on memes, videos, games, or AI agents, Chatterbox brings your content to life. It's also the first open source TTS model to support **emotion exaggeration control**, a powerful feature that makes your voices stand out. Try it now on our [Hugging Face Gradio app.](https://huggingface.co/spaces/ResembleAI/Chatterbox)
 


### PR DESCRIPTION
This is definitely a nitpick, as someone who forgot what TTS stood for and followed a Hacker News link, this disambiguation would have saved me a minute of scratching my head.

In general, I do favour the practice of writing out an acronym on first usage to make prose accessible to a variety of audiences. (Yes this is github, yes this is under an AI org, but the point still stands, and it is a minor change).