### PR TITLE
build: relax those deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,15 +10,15 @@ authors = [
 ]
 dependencies = [
     "numpy>=1.26.0",
-    "librosa==0.11.0",
+    "librosa>=0.11.0",
     "s3tokenizer",
-    "torch==2.6.0",
-    "torchaudio==2.6.0",
-    "transformers==4.46.3",
-    "diffusers==0.29.0",
-    "resemble-perth==1.0.1",
-    "conformer==0.3.2",
-    "safetensors==0.5.3"
+    "torch>=2.6.0",
+    "torchaudio>=2.6.0",
+    "transformers>=4.46.3",
+    "diffusers>=0.29.0",
+    "resemble-perth>=1.0.1",
+    "conformer>=0.3.2",
+    "safetensors>=0.5.3"
 ]
 
 [project.urls]


### PR DESCRIPTION
The repo has very constraining dependency requirements.
This PR relaxes them so that it can be installed without pinning the .venv