### PR TITLE
feat: Add AMD GPU detection for ROCm

### DIFF
--- a/example_tts.py
+++ b/example_tts.py
@@ -5,6 +5,9 @@ from chatterbox.tts import ChatterboxTTS
 # Automatically detect the best available device
 if torch.cuda.is_available():
     device = "cuda"
+# Check for AMD ROCm support
+elif torch.cuda.is_available() and torch.version.hip:
+    device = "cuda"
 elif torch.backends.mps.is_available():
     device = "mps"
 else:


### PR DESCRIPTION
#### This change adds support for AMD GPUs by checking for ROCm compatibility in PyTorch, allowing users with AMD hardware to leverage GPU acceleration.

## Changes
#### In example_tts.py incorporating a check for AMD GPUs via ROCm 

#### from this to
```python
# Automatically detect the best available device
if torch.cuda.is_available():
    device = "cuda"
elif torch.backends.mps.is_available():
    device = "mps"
else:
    device = "cpu"
```

#### this
```python
# Automatically detect the best available device
if torch.cuda.is_available():
    device = "cuda"
# Check for AMD ROCm support
elif torch.cuda.is_available() and torch.version.hip:
    device = "cuda"
elif torch.backends.mps.is_available():
    device = "mps"
else:
    device = "cpu"
```
