### PR TITLE
release 0.2.0 - define all transitive dependencies and pin within semvar major.minor range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,25 +1,74 @@
 [project]
 name = "chatterbox-tts"
-version = "0.1.2"
+version = "0.2.0"
 description = "Chatterbox: Open Source TTS and Voice Conversion by Resemble AI"
 readme = "README.md"
 requires-python = ">=3.9"
-license = {file = "LICENSE"}
-authors = [
-    {name = "resemble-ai", email = "engineering@resemble.ai"}
-]
+license = { file = "LICENSE" }
+authors = [{ name = "resemble-ai", email = "engineering@resemble.ai" }]
 dependencies = [
-    "numpy>=1.26.0",
-    "librosa==0.11.0",
-    "s3tokenizer",
-    "torch==2.6.0",
-    "torchaudio==2.6.0",
-    "transformers==4.46.3",
-    "diffusers==0.29.0",
-    "resemble-perth==1.0.1",
-    "conformer==0.3.2",
-    "safetensors==0.5.3"
+    "audioread>=3.0,<4.0",
+    "certifi>=2025.7.14",
+    "cffi>=1.17,<2.0",
+    "cfgv>=3.4,<4.0",
+    "charset-normalizer>=3.4,<4.0",
+    "conformer>=0.3,<1.0",
+    "decorator>=5.2,<6.0",
+    "diffusers>=0.34,<1.0",
+    "distlib>=0.4,<1.0",
+    "einops>=0.8,<1.0",
+    "filelock>=3.18,<4.0",
+    "fsspec>=2025.7.0,<2026.0",
+    "hf-xet>=1.1,<2.0",
+    "huggingface-hub>=0.34,<1.0",
+    "identify>=2.6,<3.0",
+    "idna>=3.10,<4.0",
+    "importlib-metadata>=8.7,<9.0",
+    "jinja2>=3.1,<4.0",
+    "joblib>=1.5,<2.0",
+    "lazy-loader>=0.4,<1.0",
+    "librosa>=0.11,<1.0",
+    "llvmlite>=0.43,<1.0",
+    "markupsafe>=3.0,<4.0",
+    "mpmath>=1.3,<2.0",
+    "msgpack>=1.1,<2.0",
+    "networkx>=3.2,<4.0",
+    "nodeenv>=1.9,<2.0",
+    "numba>=0.60,<1.0",
+    "numpy>=2,<3.0",
+    "onnx>=1.18,<2.0",
+    "packaging>=25.0,<26.0",
+    "pillow>=11.3,<12.0",
+    "platformdirs>=4.3,<5.0",
+    "pooch>=1.8,<2.0",
+    "pre-commit>=4.2,<5.0",
+    "protobuf>=6.31,<7.0",
+    "pycparser>=2.22,<3.0",
+    "pyyaml>=6.0,<7.0",
+    "regex>=2025.7.34",
+    "requests>=2.32,<3.0",
+    "resemble-perth>=1.0,<2.0",
+    "s3tokenizer>=0.2,<1.0",
+    "safetensors>=0.5,<1.0",
+    "scikit-learn>=1.6,<2.0",
+    "scipy>=1.13,<2.0",
+    "soundfile>=0.13,<1.0",
+    "soxr>=0.5.0.post1,<1.0",
+    "sympy>=1.14,<2.0",
+    "threadpoolctl>=3.6,<4.0",
+    "tokenizers>=0.21,<1.0",
+    "torch>=2.7,<3.0",
+    "torchaudio>=2.7,<3.0",
+    "tqdm>=4.67.1,<5.0",
+    "transformers>=4.54,<5.0",
+    "typing-extensions>=4.14,<5.0",
+    "urllib3>=2.5,<3.0",
+    "virtualenv>=20.32,<21.0",
+    "zipp>=3.23,<4.0",
 ]
+
+[project.optional-dependencies]
+demo = ["gradio>=5.33,<6.0"]
 
 [project.urls]
 Homepage = "https://github.com/resemble-ai/chatterbox"


### PR DESCRIPTION
# Pin All Dependencies Within Semver Minor Range

  This PR comprehensively defines the project's dependency management to pin all dependencies within semver major.minor ranges, improving flexibility when `chatterbox-tts` is used as a dependency from an app-layer such as my own https://github.com/anthonywu/gensay

  - Bumped this library's version from 0.1.2 to 0.2.0 to reflect dependency management changes
  - Pinned all 50+ dependencies to specific minor versions as discovered on 2025-07-31 (e.g., >=1.0,<2.0 format)
  - Dependency versions are compatible with status quo Python 3.9, verified via `uv tool install -p 3.9 chatterbox-tts` which is an isolated install check/solve
  - Sorted dependencies alphabetically for better maintainability
  - Added optional demo dependency group for Gradio
  - Updated core dependencies: numpy (1.26.0 → >=2,<3.0), torch (2.6.0 → >=2.7,<3.0), transformers (4.46.3 → >=4.54,<5.0)
  - Added missing transitive dependencies explicitly to ensure consistent environments
  - All dependencies now follow consistent semver minor range pinning pattern

This change ensures this library can be depended on by another application without unreasonably constraining to a set of lib versions `==`ed during a very specific point in time, which would cause increasing number of `pip install` resolution errors as time passes.