### PR TITLE
Add Windows start/install scripts & RTX 5080 (cu128) PyTorch note

### DIFF
--- a/Install.bat
+++ b/Install.bat
@@ -1,0 +1,58 @@
+@echo off
+setlocal EnableExtensions
+
+REM Detect and load conda if not on PATH
+where conda >nul 2>&1
+if errorlevel 1 (
+  for %%A in (
+    "%UserProfile%\anaconda3\condabin\conda.bat"
+    "C:\ProgramData\anaconda3\condabin\conda.bat"
+    "%UserProfile%\miniconda3\condabin\conda.bat"
+    "C:\ProgramData\miniconda3\condabin\conda.bat"
+  ) do (
+    if exist %%~A call "%%~A" activate
+  )
+)
+
+call conda --version >nul 2>&1 || (
+  color 0C
+  echo.
+  echo ================================================================
+  echo   CONDA NOT FOUND
+  echo   Install Anaconda, then reopen your terminal:
+  echo     https://www.anaconda.com/download
+  echo ================================================================
+  color 07
+  start "" "https://www.anaconda.com/download"
+  pause
+  exit /b 1
+)
+
+set "ENV_NAME=chatterbox"
+call conda env list | findstr /i " %ENV_NAME% " >nul
+if errorlevel 1 (
+  echo Creating env %ENV_NAME% with Python 3.11...
+  call conda create -y -n %ENV_NAME% python=3.11 || exit /b 1
+) else (
+  echo Env %ENV_NAME% already exists.
+)
+
+call conda activate %ENV_NAME% || exit /b 1
+
+where git >nul 2>&1 || (echo [ERROR] git not found in PATH.& exit /b 1)
+
+if not exist ".git" (
+  echo [ERROR] This script must be run inside an existing chatterbox repo.
+  echo Run: git clone https://github.com/resemble-ai/chatterbox.git
+  exit /b 1
+) else (
+  echo Repo already present. Pulling latest...
+  git pull
+)
+
+python -m pip install -U pip || exit /b 1
+pip install numpy || exit /b 1
+pip install -e "%cd%" || exit /b 1
+
+echo [OK] Chatterbox installed in conda env '%ENV_NAME%'.
+endlocal

--- a/README.md
+++ b/README.md
@@ -56,6 +56,37 @@ pip install -e .
 ```
 We developed and tested Chatterbox on Python 3.11 on Debian 11 OS; the versions of the dependencies are pinned in `pyproject.toml` to ensure consistency. You can modify the code or dependencies in this installation mode.
 
+## Windows start scripts and Torch / RTX 5080 notes
+
+This repository includes helper Windows batch scripts in the project root to simplify installation and launching on Windows. The scripts are written to detect and (when necessary) make `conda` available, create or activate a `chatterbox` environment, and install a compatible PyTorch build for your GPU.
+
+- `Install.bat`: First-time setup helper that attempts to locate `conda`, create the `chatterbox` environment (Python 3.11), install the package in editable mode, and install basic Python dependencies. Run this once when setting up a new Windows machine.
+- `StartMenu.bat`: A simple menu wrapper that lets you choose to run the installer or launch the app for either RTX 5080 (nightly cu128) or classic Nvidia GPUs (conda cu121). It also opens the Anaconda download page if `conda` is not found.
+- `Start_5080.bat`: Targeted for Nvidia RTX 5080 (CUDA 12.8 / cu128). This script checks for an existing `torch` installation with a compatible CUDA tag and installs the nightly `torch` + CUDA 12.8 wheels via pip when needed. Use this script if you have an RTX 5080 or other GPUs that require the cu128 wheel.
+- `Start_Classic.bat`: Targeted for other Nvidia GPUs and installs PyTorch + `pytorch-cuda=12.1` via `conda` to provide a stable, compatible runtime. `Start_Classic.bat` will intentionally block on RTX 50xx GPUs and instruct users to use `Start_5080.bat` instead.
+
+Notes and manual commands
+
+- The `Start_5080.bat` script uses the following commands when it needs to install the cu128 nightly wheels:
+
+```shell
+pip uninstall -y torch torchvision torchaudio
+pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
+```
+
+- The `Start_Classic.bat` script uses the conda package for CUDA 12.1 via:
+
+```shell
+pip uninstall -y torch torchvision torchaudio
+conda install -y pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch -c nvidia
+```
+
+- Both scripts perform a runtime check using Python to verify `torch.cuda.is_available()` and whether the installed `torch` matches the expected CUDA build tag before attempting to install. Ensure your Nvidia drivers and CUDA runtime are compatible with the target wheel you install.
+
+- These scripts assume Anaconda or Miniconda is present on the system. If `conda` is not available, `StartMenu.bat` will open the Anaconda download page and exit with instructions.
+
+If you prefer manual control, you can run the commands above yourself in an activated `chatterbox` conda environment.
+
 # Usage
 ```python
 import torchaudio as ta

--- a/StartMenu.bat
+++ b/StartMenu.bat
@@ -1,0 +1,102 @@
+@echo off
+setlocal EnableExtensions
+cd /d "%~dp0"
+
+REM ================================================
+REM Try to make conda available without requiring "conda init"
+REM ================================================
+where conda >nul 2>&1
+if errorlevel 1 (
+  for %%A in (
+    "%UserProfile%\anaconda3\condabin\conda.bat"
+    "C:\ProgramData\anaconda3\condabin\conda.bat"
+    "%UserProfile%\miniconda3\condabin\conda.bat"
+    "C:\ProgramData\miniconda3\condabin\conda.bat"
+  ) do (
+    if exist %%~A call "%%~A" activate
+  )
+)
+
+call conda --version >nul 2>&1
+if errorlevel 1 goto no_conda
+
+REM ================================================
+REM Main menu
+REM ================================================
+:menu
+echo.
+echo ================================================
+echo   Select action
+echo   0) Install (Only First time !)
+echo   1) Launch for Nvidia RTX 5080 (nightly CUDA 12.8 - cu128)
+echo   2) Launch for Nvidia Classic (CUDA 12.1 - cu121)
+echo   Q) Quit
+echo ================================================
+set "CHOICE="
+set /p "CHOICE=Enter choice [0/1/2/Q]: "
+
+if /i "%CHOICE%"=="0" goto run_install
+if /i "%CHOICE%"=="1" goto go5080
+if /i "%CHOICE%"=="2" goto goclassic
+if /i "%CHOICE%"=="Q" goto end
+if /i "%CHOICE%"=="q" goto end
+
+echo [WARN] Invalid choice.
+goto menu
+
+:run_install
+if exist "%~dp0Install.bat" (
+  echo [INFO] Running Install.bat...
+  call "%~dp0Install.bat"
+) else (
+  echo [ERROR] Install.bat not found next to this script.
+  echo         Put Install.bat in the same folder then retry.
+  pause
+)
+goto menu
+
+:go5080
+if exist "%~dp0Start_5080.bat" (
+  call "%~dp0Start_5080.bat"
+) else (
+  echo [ERROR] Start_5080.bat not found next to this script.
+  pause
+)
+goto menu
+
+:goclassic
+if exist "%~dp0Start_Classic.bat" (
+  call "%~dp0Start_Classic.bat"
+) else (
+  echo [ERROR] Start_Classic.bat not found next to this script.
+  pause
+)
+goto menu
+
+:end
+endlocal
+exit /b 0
+
+:no_conda
+color 0C
+echo.
+echo ================================================================
+echo   CONDA NOT FOUND
+echo   This project requires Anaconda or Miniconda on Windows.
+echo.
+echo   Get Anaconda (recommended):
+echo     https://www.anaconda.com/download
+echo.
+echo   Alternative (Miniconda):
+echo     https://docs.conda.io/en/latest/miniconda.html
+echo.
+echo   After installation, just reopen this StartMenu.bat.
+echo   You do NOT need to run "conda init".
+echo ================================================================
+color 07
+start "" "https://www.anaconda.com/download"
+REM Optional: also open Miniconda page
+REM start "" "https://docs.conda.io/en/latest/miniconda.html"
+pause
+endlocal
+exit /b 1

--- a/Start_5080.bat
+++ b/Start_5080.bat
@@ -1,0 +1,147 @@
+@echo off
+setlocal EnableExtensions
+set "ENV_NAME=chatterbox"
+cd /d "%~dp0"
+
+REM --- Load conda if not on PATH ---
+where conda >nul 2>&1
+if errorlevel 1 (
+  if exist "%UserProfile%\miniconda3\condabin\conda.bat" call "%UserProfile%\miniconda3\condabin\conda.bat" activate
+  if exist "C:\ProgramData\miniconda3\condabin\conda.bat" call "C:\ProgramData\miniconda3\condabin\conda.bat" activate
+  if exist "%UserProfile%\anaconda3\condabin\conda.bat" call "%UserProfile%\anaconda3\condabin\conda.bat" activate
+  if exist "C:\ProgramData\anaconda3\condabin\conda.bat" call "C:\ProgramData\anaconda3\condabin\conda.bat" activate
+)
+
+call conda --version >nul 2>&1
+if errorlevel 1 (
+  echo [ERROR] conda not found. Run: conda init cmd.exe then reopen terminal.
+  exit /b 1
+)
+
+REM --- Ensure env and activate ---
+call conda env list | findstr /i " %ENV_NAME% " >nul
+if errorlevel 1 (
+  echo [INFO] Creating env %ENV_NAME% - Python 3.11
+  call conda create -y -n %ENV_NAME% python=3.11
+  if errorlevel 1 (
+    echo [ERROR] conda create failed.
+    exit /b 1
+  )
+) else (
+  echo [INFO] Env %ENV_NAME% already exists.
+)
+
+call conda activate %ENV_NAME%
+if errorlevel 1 (
+  echo [ERROR] conda activate failed.
+  exit /b 1
+)
+
+python -m pip install -U pip
+
+REM --- Check if torch nightly cu128 + CUDA is OK (do not reinstall if OK) ---
+python -c "import sys,pkgutil; sys.exit(0 if pkgutil.find_loader('torch') else 1)"
+if errorlevel 1 goto install_torch
+
+python -c "import sys,torch; ok = torch.cuda.is_available() and (('+cu128' in getattr(torch,'__version__','')) or ('12.8' in (getattr(torch.version,'cuda','') or ''))); print('torch=',getattr(torch,'__version__','?')); print('cuda=',getattr(torch.version,'cuda',None)); print('cuda_available=',torch.cuda.is_available()); print(torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'no gpu'); sys.exit(0 if ok else 1)"
+if errorlevel 1 goto install_torch
+goto torch_ok
+
+:install_torch
+echo [INFO] Installing torch nightly cu128
+pip uninstall -y torch torchvision torchaudio >nul 2>&1
+call conda remove -y pytorch torchvision torchaudio pytorch-cuda >nul 2>&1
+pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
+if errorlevel 1 (
+  echo [ERROR] torch nightly cu128 install failed.
+  exit /b 1
+)
+
+:torch_ok
+python -c "import torch,sys; print('torch=',torch.__version__); print('cuda=',getattr(torch.version,'cuda',None)); print('cuda_available=',torch.cuda.is_available()); print(torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'no gpu'); sys.exit(0 if torch.cuda.is_available() else 1)"
+if errorlevel 1 (
+  echo [ERROR] CUDA not available after torch install.
+  exit /b 1
+)
+
+REM --- Pin numeric stack only if needed (numpy 1.25.x, scipy 1.11.x, sklearn 1.3.x) ---
+python -c "import sys; import numpy,scipy,sklearn; sys.exit(0 if (numpy.__version__.startswith('1.25.') and scipy.__version__.startswith('1.11.') and sklearn.__version__.startswith('1.3.')) else 1)" 1>nul 2>nul
+if errorlevel 1 (
+  echo [INFO] Pinning numpy/scipy/sklearn for repo compatibility
+  pip uninstall -y numpy scipy scikit-learn >nul 2>&1
+  pip install --no-deps numpy==1.25.2 scipy==1.11.4 scikit-learn==1.3.2
+)
+
+REM --- Multilingual extras (PKU, Kakasi, charset, MCP) ---
+python -c "import sys,pkgutil; sys.exit(0 if pkgutil.find_loader('pkuseg') else 1)" 1>nul 2>nul
+if errorlevel 1 pip install pkuseg
+
+python -c "import sys,pkgutil; sys.exit(0 if pkgutil.find_loader('pykakasi') else 1)" 1>nul 2>nul
+if errorlevel 1 pip install pykakasi
+
+python -c "import sys,pkgutil; sys.exit(0 if pkgutil.find_loader('charset_normalizer') else 1)" 1>nul 2>nul
+if errorlevel 1 pip install charset-normalizer
+
+python -c "import sys,pkgutil; sys.exit(0 if pkgutil.find_loader('mcp') else 1)" 1>nul 2>nul
+if errorlevel 1 pip install "gradio[mcp]"
+
+REM --- Install repo editable ONLY if not already importable ---
+python -c "import sys,pkgutil; sys.exit(0 if pkgutil.find_loader('chatterbox') else 1)" 1>nul 2>nul
+if errorlevel 1 (
+  echo [INFO] Installing repo in editable mode without deps
+  pip install -e "%cd%" --no-deps
+  if errorlevel 1 (
+    echo [ERROR] editable install failed.
+    exit /b 1
+  )
+) else (
+  echo [INFO] chatterbox already importable, skipping editable install
+)
+
+REM --- Non-torch pinned deps (no-deps to keep numeric pins) ---
+pip install --no-deps diffusers==0.29.0 transformers==4.46.3 librosa==0.11.0 s3tokenizer==0.2.0 conformer==0.3.2 resemble-perth==1.0.1 safetensors==0.5.3
+
+REM --- Sanity check ---
+python -c "import torch,numpy,scipy,librosa; print('torch',torch.__version__,'cuda',getattr(torch.version,'cuda',None),'cuda_ok',torch.cuda.is_available()); print('numpy',numpy.__version__); print('scipy',scipy.__version__); print('librosa',librosa.__version__)"
+
+REM --- Librosa runtime deps (au cas où) ---
+for %%M in (lazy_loader soundfile audioread soxr pooch) do (
+  python -c "import importlib,sys; sys.exit(0 if importlib.util.find_spec('%%M') else 1)" 1>nul 2>nul
+  if errorlevel 1 pip install %%M
+)
+
+REM --- App menu ---
+:menu
+echo.
+echo ================================================
+echo   Select app to run   [PyTorch: nightly cu128]
+echo   1) gradio_tts_app.py
+echo   2) gradio_vc_app.py
+echo   3) multilingual_app.py
+echo   Q) Quit
+echo ================================================
+set "CHOICE="
+set /p "CHOICE=Enter choice [1/2/3/Q]: "
+
+if /i "%CHOICE%"=="1" goto run_tts
+if /i "%CHOICE%"=="2" goto run_vc
+if /i "%CHOICE%"=="3" goto run_multi
+if /i "%CHOICE%"=="Q" goto end
+if /i "%CHOICE%"=="q" goto end
+echo Invalid choice.
+goto menu
+
+:run_tts
+python gradio_tts_app.py
+goto menu
+
+:run_vc
+python gradio_vc_app.py
+goto menu
+
+:run_multi
+python multilingual_app.py
+goto menu
+
+:end
+endlocal

--- a/Start_Classic.bat
+++ b/Start_Classic.bat
@@ -1,0 +1,143 @@
+@echo off
+setlocal EnableExtensions
+set "ENV_NAME=chatterbox"
+cd /d "%~dp0"
+
+REM --- Load conda if not on PATH ---
+where conda >nul 2>&1
+if errorlevel 1 (
+  if exist "%UserProfile%\miniconda3\condabin\conda.bat" call "%UserProfile%\miniconda3\condabin\conda.bat" activate
+  if exist "C:\ProgramData\miniconda3\condabin\conda.bat" call "C:\ProgramData\miniconda3\condabin\conda.bat" activate
+  if exist "%UserProfile%\anaconda3\condabin\conda.bat" call "%UserProfile%\anaconda3\condabin\conda.bat" activate
+  if exist "C:\ProgramData\anaconda3\condabin\conda.bat" call "C:\ProgramData\anaconda3\condabin\conda.bat" activate
+)
+
+call conda --version >nul 2>&1
+if errorlevel 1 (
+  echo [ERROR] conda not found. Run: conda init cmd.exe then reopen terminal.
+  exit /b 1
+)
+
+REM --- Block on RTX 50xx because cu121 is not compatible ---
+python -c "import torch,sys; sys.exit(1 if (torch.cuda.is_available() and 'RTX 50' in torch.cuda.get_device_name(0)) else 0)" 1>nul 2>nul
+if errorlevel 1 (
+  echo [ERROR] This script cannot run on RTX 50xx GPUs. Use Start_5080.bat instead.
+  pause
+  exit /b 1
+)
+
+REM --- Ensure env and activate ---
+call conda env list | findstr /i " %ENV_NAME% " >nul
+if errorlevel 1 (
+  echo [INFO] Creating env %ENV_NAME% - Python 3.11
+  call conda create -y -n %ENV_NAME% python=3.11
+  if errorlevel 1 (
+    echo [ERROR] conda create failed.
+    exit /b 1
+  )
+) else (
+  echo [INFO] Env %ENV_NAME% already exists.
+)
+
+call conda activate %ENV_NAME%
+if errorlevel 1 (
+  echo [ERROR] conda activate failed.
+  exit /b 1
+)
+
+python -m pip install -U pip
+
+REM --- Check if torch cu121 via conda is OK (do not reinstall if OK) ---
+python -c "import sys,pkgutil; sys.exit(0 if pkgutil.find_loader('torch') else 1)"
+if errorlevel 1 goto install_torch
+
+python -c "import sys,torch; ok=torch.cuda.is_available() and (('12.1' in (getattr(torch.version,'cuda','') or '')) or ('+cu121' in getattr(torch,'__version__',''))); print('torch=',getattr(torch,'__version__','?')); print('cuda=',getattr(torch.version,'cuda',None)); print('cuda_available=',torch.cuda.is_available()); print(torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'no gpu'); sys.exit(0 if ok else 1)"
+if errorlevel 1 goto install_torch
+goto torch_ok
+
+:install_torch
+echo [INFO] Installing torch stable cu121 via conda
+pip uninstall -y torch torchvision torchaudio >nul 2>&1
+call conda install -y pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch -c nvidia
+if errorlevel 1 (
+  echo [ERROR] conda pytorch-cuda=12.1 failed.
+  exit /b 1
+)
+
+:torch_ok
+python -c "import torch;print('torch=',torch.__version__);print('cuda=',getattr(torch.version,'cuda',None));print('cuda_available=',torch.cuda.is_available());print(torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'no gpu')"
+
+REM --- Pin numeric stack via conda only if not already pinned ---
+python -c "import sys; import numpy,scipy,sklearn; sys.exit(0 if (numpy.__version__.startswith('1.25.') and scipy.__version__.startswith('1.11.') and sklearn.__version__.startswith('1.3.')) else 1)" 1>nul 2>nul
+if errorlevel 1 (
+  echo [INFO] Ensuring numeric stack via conda
+  call conda install -y numpy=1.25.* scipy=1.11.* scikit-learn=1.3.*
+)
+
+REM --- Multilingual extras (do not touch torch) ---
+python -c "import sys,pkgutil; sys.exit(0 if pkgutil.find_loader('pkuseg') else 1)" 1>nul 2>nul
+if errorlevel 1 pip install pkuseg
+
+python -c "import sys,pkgutil; sys.exit(0 if pkgutil.find_loader('pykakasi') else 1)" 1>nul 2>nul
+if errorlevel 1 pip install pykakasi
+
+python -c "import sys,pkgutil; sys.exit(0 if pkgutil.find_loader('charset_normalizer') else 1)" 1>nul 2>nul
+if errorlevel 1 pip install charset-normalizer
+
+python -c "import sys,pkgutil; sys.exit(0 if pkgutil.find_loader('mcp') else 1)" 1>nul 2>nul
+if errorlevel 1 pip install "gradio[mcp]"
+
+REM --- Install repo editable WITHOUT deps (avoid touching torch) ---
+python -c "import sys,pkgutil; sys.exit(0 if pkgutil.find_loader('chatterbox') else 1)" 1>nul 2>nul
+if errorlevel 1 (
+  echo [INFO] Installing repo editable (no deps)
+  pip install -e "%cd%" --no-deps
+  if errorlevel 1 (
+    echo [ERROR] editable install failed.
+    exit /b 1
+  )
+) else (
+  echo [INFO] chatterbox already importable, skipping editable install
+)
+
+REM --- Non-torch pinned deps, no-deps to avoid numpy changes ---
+pip install --no-deps diffusers==0.29.0 transformers==4.46.3 librosa==0.11.0 s3tokenizer==0.2.0 conformer==0.3.2 resemble-perth==1.0.1 safetensors==0.5.3
+
+REM --- Sanity check ---
+python -c "import torch,numpy,scipy,librosa; print('torch',torch.__version__,'cuda',getattr(torch.version,'cuda',None),'cuda_ok',torch.cuda.is_available()); print('numpy',numpy.__version__); print('scipy',scipy.__version__); print('librosa',librosa.__version__)"
+
+REM --- App menu ---
+:menu
+echo.
+echo ================================================
+echo   Select app to run   [PyTorch: conda cu121]
+echo   1) gradio_tts_app.py
+echo   2) gradio_vc_app.py
+echo   3) multilingual_app.py
+echo   Q) Quit
+echo ================================================
+set "CHOICE="
+set /p "CHOICE=Enter choice [1/2/3/Q]: "
+
+if /i "%CHOICE%"=="1" goto run_tts
+if /i "%CHOICE%"=="2" goto run_vc
+if /i "%CHOICE%"=="3" goto run_multi
+if /i "%CHOICE%"=="Q" goto end
+if /i "%CHOICE%"=="q" goto end
+echo Invalid choice.
+goto menu
+
+:run_tts
+python gradio_tts_app.py
+goto menu
+
+:run_vc
+python gradio_vc_app.py
+goto menu
+
+:run_multi
+python multilingual_app.py
+goto menu
+
+:end
+endlocal


### PR DESCRIPTION
Title:
Add Windows start/install scripts and RTX 5080 (cu128) PyTorch note

Description:
This PR adds Windows helper batch scripts to simplify installation and launching on Windows: `Install.bat`, `StartMenu.bat`, `Start_5080.bat`, and `Start_Classic.bat`. 

- Adds a README section documenting the scripts and installation flow.
- RTX 5080 (RTX 50xx) users: use `Start_5080.bat` — the script validates the environment and installs/uses the cu128 nightly PyTorch wheels (required for RTX 5080). Do NOT use `Start_Classic.bat` on RTX 50xx devices.
- Other NVIDIA GPUs: use `Start_Classic.bat` (conda + `pytorch-cuda=12.1`) for a stable runtime.
- Scripts perform runtime checks (conda presence, `torch` CUDA tag, `torch.cuda.is_available()`) and provide guidance if dependencies or drivers are missing.

This makes Windows setup straightforward and documents the recommended PyTorch/CUDA choices for different GPU families.