### PR TITLE
Add CFG condition for batch size adjustments

### DIFF
--- a/src/chatterbox/models/t3/t3.py
+++ b/src/chatterbox/models/t3/t3.py
@@ -302,8 +302,9 @@ class T3(nn.Module):
         bos_embed = self.speech_emb(bos_token)  # shape: (B, 1, embed_dim)
         bos_embed = bos_embed + self.speech_pos_emb.get_fixed_embedding(0)
 
-        # batch_size=2 for CFG
-        bos_embed = torch.cat([bos_embed, bos_embed])
+        if cfg_weight > 0.0:
+            # batch_size=2 for CFG
+            bos_embed = torch.cat([bos_embed, bos_embed], dim=0)
 
         # Combine condition and BOS token for the initial input
         inputs_embeds = torch.cat([embeds, bos_embed], dim=1)
@@ -333,11 +334,14 @@ class T3(nn.Module):
         # ---- Generation Loop using kv_cache ----
         for i in tqdm(range(max_new_tokens), desc="Sampling", dynamic_ncols=True):
             logits_step = output.logits[:, -1, :]                
-            # CFG combine  → (1, V)
-            cond   = logits_step[0:1, :]
-            uncond = logits_step[1:2, :]
-            cfg = torch.as_tensor(cfg_weight, device=cond.device, dtype=cond.dtype)
-            logits = cond + cfg * (cond - uncond)
+            if cfg_weight > 0.0:
+                # CFG combine  → (1, V)
+                cond   = logits_step[0:1, :]
+                uncond = logits_step[1:2, :]
+                cfg = torch.as_tensor(cfg_weight, device=cond.device, dtype=cond.dtype)
+                logits = cond + cfg * (cond - uncond)
+            else:
+                logits = logits_step
             
             # Apply alignment stream analyzer integrity checks
             if self.patched_model.alignment_stream_analyzer is not None:
@@ -376,7 +380,8 @@ class T3(nn.Module):
             next_token_embed = next_token_embed + self.speech_pos_emb.get_fixed_embedding(i + 1)
 
             #  For CFG
-            next_token_embed = torch.cat([next_token_embed, next_token_embed])
+            if cfg_weight > 0.0:
+                next_token_embed = torch.cat([next_token_embed, next_token_embed])
 
             # Forward pass with only the new token and the cached past.
             output = self.patched_model(


### PR DESCRIPTION
Currently, cfg_weight=0.0 fails because the current inference code assumes we always perform classifier free guidance. As a result, the following code fails:
```py
import torchaudio as ta
from chatterbox.tts import ChatterboxTTS

model = ChatterboxTTS.from_pretrained(device="cpu")

text = "Ezreal and Jinx teamed up with Ahri, Yasuo, and Teemo to take down the enemy's Nexus in an epic late-game pentakill."
wav = model.generate(text, cfg_weight=0.0)
ta.save("test-1.wav", wav, model.sr)
```

with this error:
```
    wav = model.generate(text, cfg_weight=0.0)
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/chatterbox/tts.py", line 246, in generate
    speech_tokens = self.t3.inference(
        t3_cond=self.conds.t3,
    ...<6 lines>...
        top_p=top_p,
    )
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/chatterbox/models/t3/t3.py", line 309, in inference
    inputs_embeds = torch.cat([embeds, bos_embed], dim=1)
RuntimeError: Sizes of tensors must match except in dimension 1. Expected size 1 but got size 2 for tensor number 1 in the list.
```

---

This PR fixes this, allowing cfg_weight to be set to 0. It's ~2x faster, but does produce slightly worse results.