### PR TITLE
fix(deps): Resolve installation conflict between gradio and spacy (typer)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "safetensors==0.5.3",
     "spacy-pkuseg",
     "pykakasi==2.3.0",
-    "gradio==5.44.1",
+    "gradio==4.33.1",
     "russian-text-stresser @ git+https://github.com/Vuizur/add-stress-to-epub",
 
 ]


### PR DESCRIPTION
Hi there,

This PR fixes an installation failure caused by a dependency conflict.

### The Problem

The project fails to install via `pip install -e .` due to incompatible requirements for the `typer` library:

1.  **`gradio==5.44.1`** (in `pyproject.toml`) requires `typer>=0.12`.
2.  **`russian-text-stresser`** (a dependency) requires `spacy==3.6.*`.
3.  **`spacy==3.6.*`** in turn requires `typer<0.10`.

The requirements `typer>=0.12` and `typer<0.10` are mutually exclusive, leading to a `ResolutionImpossible` error.

### The Solution

I have downgraded `gradio` from `5.44.1` to `4.33.1` (the latest 4.x release).

Gradio version 4.x removed its direct dependency on `typer`, which successfully resolves this conflict. The installation now completes successfully.

Let me know if you'd like any changes!