### PR TITLE
fix dependencies to run example_for_mac.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ dependencies = [
     "pykakasi==2.3.0",
     "gradio==5.44.1",
     "pyloudnorm",
-    "omegaconf"
+    "omegaconf",
+    "onnx<1.17",
+    "setuptools"
 ]
 
 [project.urls]


### PR DESCRIPTION
onnx needs to be pinned and setuptools are required.