### PR TITLE
fix: relax numpy version constraint for Python 3.12+ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "resemble-ai", email = "engineering@resemble.ai"}
 ]
 dependencies = [
-    "numpy>=1.24.0,<1.26.0",
+    "numpy>=1.24.0,<2.0.0",
     "librosa==0.11.0",
     "s3tokenizer",
     "torch==2.6.0",


### PR DESCRIPTION
## Summary
- Relax numpy version constraint from `>=1.24.0,<1.26.0` to `>=1.24.0,<2.0.0`
- Enables installation on Python 3.12 and 3.13

## Problem
Fixes #392, #341, #349

The numpy<1.26.0 constraint prevented installation on Python 3.12+ because older numpy versions cannot be built from source (pkgutil.ImpImporter was removed in Python 3.12).

## Solution
Changed to `>=1.24.0,<2.0.0` to allow prebuilt numpy wheels for Python 3.12/3.13 while maintaining numpy 1.x API compatibility.

## Test
Verified the package can be installed with `pip install -e .` on Python 3.12+.