### PR TITLE
fix: use eager attention for SDPA compatibility with transformers >=4.36

### DIFF
--- a/src/chatterbox/models/t3/t3.py
+++ b/src/chatterbox/models/t3/t3.py
@@ -60,7 +60,7 @@ class T3(nn.Module):
             self.cfg = GPT2Config(**config_dict)
             self.tfmr = GPT2Model(self.cfg)
         else:
-            self.cfg = LlamaConfig(**config_dict)
+            self.cfg = LlamaConfig(**config_dict, attn_implementation="eager")
             self.tfmr = LlamaModel(self.cfg)
 
         self.dim = self.cfg.hidden_size

--- a/src/chatterbox/models/t3/t3.py
+++ b/src/chatterbox/models/t3/t3.py
@@ -60,7 +60,7 @@ class T3(nn.Module):
             self.cfg = GPT2Config(**config_dict)
             self.tfmr = GPT2Model(self.cfg)
         else:
-            self.cfg = LlamaConfig(**config_dict, attn_implementation="eager")
+            self.cfg = LlamaConfig(**config_dict)
             self.tfmr = LlamaModel(self.cfg)
 
         self.dim = self.cfg.hidden_size


### PR DESCRIPTION
## Summary
- Set `attn_implementation='eager'` when creating LlamaConfig
- Ensures `output_attentions=True` works correctly

## Problem
Fixes #339

In transformers >=4.36, SDPA became the default attention implementation. However, SDPA doesn't support `output_attentions=True`, which Chatterbox uses during inference with voice references.

This causes:
```
ValueError: The `output_attentions` attribute is not supported when using the `attn_implementation` set to sdpa.
```

## Solution
Explicitly set `attn_implementation='eager'` in LlamaConfig. Eager attention fully supports all features including output_attentions.

## Impact
- Voice cloning and voice conversion features now work with modern transformers versions
- No performance regression for typical use cases (inference already uses output_attentions)