### PR TITLE
fix: Enable Hebrew diacritization with dicta-onnx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "pykakasi==2.3.0",
     "gradio==5.44.1",
     "pyloudnorm",
-    "omegaconf"
+    "omegaconf",
+    "dicta-onnx>=1.0.9"
 ]
 
 [project.urls]


### PR DESCRIPTION
Add dicta-onnx dependency to fix Hebrew TTS support. Previously Hebrew text processing failed due to missing dependency.