### PR TITLE
fix: Support Python 3.12 by relaxing numpy version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "resemble-ai", email = "engineering@resemble.ai"}
 ]
 dependencies = [
-    "numpy>=1.24.0,<1.26.0",
+    "numpy>=1.24.0,<2.0.0",
     "librosa==0.11.0",
     "s3tokenizer",
     "torch==2.6.0",


### PR DESCRIPTION
## Summary
  Relax numpy version constraint from `>=1.24.0,<1.26.0` to `>=1.24.0,<2.0.0`
  Enables installation on Python 3.12 and 3.13

  ## Problem
  Fixes #77, #104, #231, #240, #243, #272, #319, #322, #323, #390

  The `numpy<1.26.0` constraint prevented installation on Python 3.12+ because numpy 1.24.x/1.25.x cannot be built from source (`pkgutil.ImpImporter` was removed in Python 3.12, and `distutils` was removed from stdlib).

  ## Solution
  Changed to `>=1.24.0,<2.0.0` to allow prebuilt numpy wheels for Python 3.12/3.13 while maintaining numpy 1.x API compatibility.

  ## Test
  Verified with `pip install -e .` on Python 3.12:
  - Installs numpy 1.26.4 
  - All imports work correctly 