### PR TITLE
typo in README fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ ta.save("test-english.wav", wav, model.sr)
 multilingual_model = ChatterboxMultilingualTTS.from_pretrained(device=device)
 
 french_text = "Bonjour, comment ça va? Ceci est le modèle de synthèse vocale multilingue Chatterbox, il prend en charge 23 langues."
-wav_french = multilingual_model.generate(spanish_text, language_id="fr")
+wav_french = multilingual_model.generate(french_text, language_id="fr")
 ta.save("test-french.wav", wav_french, model.sr)
 
 chinese_text = "你好，今天天气真不错，希望你有一个愉快的周末。"


### PR DESCRIPTION
This PR fixes a small typo in the Multilingual model section of the README that could confuse users.

Specifically, in the French example, multilingual_model.generate() incorrectly uses spanish_text instead of french_text. This has been corrected.

No functional changes.