### PR TITLE
Add support for local model path in from_pretrained methods

### DIFF
--- a/src/chatterbox/mtl_tts.py
+++ b/src/chatterbox/mtl_tts.py
@@ -191,7 +191,13 @@ class ChatterboxMultilingualTTS:
         return cls(t3, s3gen, ve, tokenizer, device, conds=conds)
 
     @classmethod
-    def from_pretrained(cls, device: torch.device) -> 'ChatterboxMultilingualTTS':
+    def from_pretrained(cls, device: torch.device, **kwargs) -> 'ChatterboxMultilingualTTS':
+
+        # Check if model_snapshot_path is provided in kwargs
+        if 'model_snapshot_path' in kwargs:
+            model_snapshot_path = Path(kwargs['model_snapshot_path'])
+            if model_snapshot_path.exists():
+                return cls.from_local(ckpt_dir=model_snapshot_path, device=device)
         ckpt_dir = Path(
             snapshot_download(
                 repo_id=REPO_ID,

--- a/src/chatterbox/tts.py
+++ b/src/chatterbox/tts.py
@@ -165,7 +165,7 @@ class ChatterboxTTS:
         return cls(t3, s3gen, ve, tokenizer, device, conds=conds)
 
     @classmethod
-    def from_pretrained(cls, device) -> 'ChatterboxTTS':
+    def from_pretrained(cls, device, **kwargs) -> 'ChatterboxTTS':
         # Check if MPS is available on macOS
         if device == "mps" and not torch.backends.mps.is_available():
             if not torch.backends.mps.is_built():
@@ -173,6 +173,11 @@ class ChatterboxTTS:
             else:
                 print("MPS not available because the current MacOS version is not 12.3+ and/or you do not have an MPS-enabled device on this machine.")
             device = "cpu"
+                # Check if model_snapshot_path is provided in kwargs
+        if 'model_snapshot_path' in kwargs:
+            model_snapshot_path = Path(kwargs['model_snapshot_path'])
+            if model_snapshot_path.exists():
+                return cls.from_local(ckpt_dir=model_snapshot_path, device=device)
 
         for fpath in ["ve.safetensors", "t3_cfg.safetensors", "s3gen.safetensors", "tokenizer.json", "conds.pt"]:
             local_path = hf_hub_download(repo_id=REPO_ID, filename=fpath)

--- a/src/chatterbox/tts_turbo.py
+++ b/src/chatterbox/tts_turbo.py
@@ -183,7 +183,7 @@ class ChatterboxTurboTTS:
         return cls(t3, s3gen, ve, tokenizer, device, conds=conds)
 
     @classmethod
-    def from_pretrained(cls, device) -> 'ChatterboxTurboTTS':
+    def from_pretrained(cls, device, **kwargs) -> 'ChatterboxTurboTTS':
         # Check if MPS is available on macOS
         if device == "mps" and not torch.backends.mps.is_available():
             if not torch.backends.mps.is_built():
@@ -191,6 +191,12 @@ class ChatterboxTurboTTS:
             else:
                 print("MPS not available because the current MacOS version is not 12.3+ and/or you do not have an MPS-enabled device on this machine.")
             device = "cpu"
+
+        # Check if model_snapshot_path is provided in kwargs
+        if 'model_snapshot_path' in kwargs:
+            model_snapshot_path = Path(kwargs['model_snapshot_path'])
+            if model_snapshot_path.exists():
+                return cls.from_local(ckpt_dir=model_snapshot_path, device=device)
 
         local_path = snapshot_download(
             repo_id=REPO_ID,

--- a/src/chatterbox/vc.py
+++ b/src/chatterbox/vc.py
@@ -59,7 +59,7 @@ class ChatterboxVC:
         return cls(s3gen, device, ref_dict=ref_dict)
 
     @classmethod
-    def from_pretrained(cls, device) -> 'ChatterboxVC':
+    def from_pretrained(cls, device, **kwargs) -> 'ChatterboxVC':
         # Check if MPS is available on macOS
         if device == "mps" and not torch.backends.mps.is_available():
             if not torch.backends.mps.is_built():
@@ -67,7 +67,13 @@ class ChatterboxVC:
             else:
                 print("MPS not available because the current MacOS version is not 12.3+ and/or you do not have an MPS-enabled device on this machine.")
             device = "cpu"
-            
+        
+        # Check if model_snapshot_path is provided in kwargs
+        if 'model_snapshot_path' in kwargs:
+            model_snapshot_path = Path(kwargs['model_snapshot_path'])
+            if model_snapshot_path.exists():
+                return cls.from_local(ckpt_dir=model_snapshot_path, device=device)
+
         for fpath in ["s3gen.safetensors", "conds.pt"]:
             local_path = hf_hub_download(repo_id=REPO_ID, filename=fpath)
 


### PR DESCRIPTION
## Add support for local model path in `from_pretrained` methods

Enhanced the `from_pretrained` class methods in both `ChatterboxMultilingualTTS`, `ChatterboxTTS`, `ChatterboxVC` and `ChatterboxTurboTTS` to accept an optional `model_snapshot_path` parameter via kwargs.

### Changes
- Modified `from_pretrained` methods to accept `**kwargs`
- Added logic to check for `model_snapshot_path` parameter
- If `model_snapshot_path` exists and is valid, the method uses the local path directly, skipping HuggingFace snapshot download
- If `model_snapshot_path` is not provided or doesn't exist, falls back to the default behavior of downloading from HuggingFace

### Benefits
- Allows users to load models from local directories without re-downloading
- Reduces bandwidth usage and initialization time for users with cached models
- Maintains backward compatibility - existing code without `model_snapshot_path` works unchanged
- Graceful fallback ensures robustness

### Usage Example
```python
# Use local model path (skips download)
model = ChatterboxMultilingualTTS.from_pretrained(
    device=device, 
    model_snapshot_path="/path/to/local/model"
)

# Default behavior (downloads from HuggingFace)
model = ChatterboxMultilingualTTS.from_pretrained(device=device)