### PR TITLE
Add device detection to example_tts_turbo

### DIFF
--- a/example_tts_turbo.py
+++ b/example_tts_turbo.py
@@ -2,8 +2,16 @@ import torchaudio as ta
 import torch
 from chatterbox.tts_turbo import ChatterboxTurboTTS
 
+# Automatically detect the best available device
+if torch.cuda.is_available():
+    device = "cuda"
+elif torch.backends.mps.is_available():
+    device = "mps"
+else:
+    device = "cpu"
+
 # Load the Turbo model
-model = ChatterboxTurboTTS.from_pretrained(device="cuda")
+model = ChatterboxTurboTTS.from_pretrained(device=device)
 
 # Generate with Paralinguistic Tags
 text = "Oh, that's hilarious! [chuckle] Um anyway, we do have a new model in store. It's the SkyNet T-800 series and it's got basically everything. Including AI integration with ChatGPT and all that jazz. Would you like me to get some prices for you?"


### PR DESCRIPTION
This adds the same device detection to example_tts_turbo as in the other examples.

However, it needs the other fixes to tensor loading (#430 for instance) to actually work throughout.