### PR TITLE
Fix README multilingual example using french_text instead of spanish_text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ![Chatterbox Turbo Image](./Chatterbox-Turbo.jpg)
 
-
 # Chatterbox TTS
 
 [![Alt Text](https://img.shields.io/badge/listen-demo_samples-blue)](https://resemble-ai.github.io/chatterbox_turbo_demopage/)
@@ -8,7 +7,7 @@
 [![Alt Text](https://static-public.podonos.com/badges/insight-on-pdns-sm-dark.svg)](https://podonos.com/resembleai/chatterbox)
 [![Discord](https://img.shields.io/discord/1377773249798344776?label=join%20discord&logo=discord&style=flat)](https://discord.gg/rJq9cRJBJ6)
 
-_Made with ♥️ by <a href="https://resemble.ai" target="_blank"><img width="100" alt="resemble-logo-horizontal" src="https://github.com/user-attachments/assets/35cf756b-3506-4943-9c72-c05ddfa4e525" /></a>
+\_Made with ♥️ by <a href="https://resemble.ai" target="_blank"><img width="100" alt="resemble-logo-horizontal" src="https://github.com/user-attachments/assets/35cf756b-3506-4943-9c72-c05ddfa4e525" /></a>
 
 **Chatterbox** is a family of three state-of-the-art, open-source text-to-speech models by Resemble AI.
 
@@ -24,18 +23,20 @@ If you like the model but need to scale or tune it for higher accuracy, check ou
 
 Choose the right model for your application.
 
-| Model                                                                                                           | Size | Languages | Key Features                                            | Best For                                     | 🤗                                                                  | Examples |
-|:----------------------------------------------------------------------------------------------------------------| :--- | :--- |:--------------------------------------------------------|:---------------------------------------------|:--------------------------------------------------------------------------| :--- |
-| **Chatterbox-Turbo**                                                                                            | **350M** | **English** | Paralinguistic Tags (`[laugh]`), Lower Compute and VRAM | Zero-shot voice agents,  Production          | [Demo](https://huggingface.co/spaces/ResembleAI/chatterbox-turbo-demo)        | [Listen](https://resemble-ai.github.io/chatterbox_turbo_demopage/) |
-| Chatterbox-Multilingual [(Language list)](#supported-languages)                                                 | 500M | 23+ | Zero-shot cloning, Multiple Languages                   | Global applications, Localization            | [Demo](https://huggingface.co/spaces/ResembleAI/Chatterbox-Multilingual-TTS) | [Listen](https://resemble-ai.github.io/chatterbox_demopage/) |
-| Chatterbox [(Tips and Tricks)](#original-chatterbox-tips)                                                       | 500M | English | CFG & Exaggeration tuning                               | General zero-shot TTS with creative controls | [Demo](https://huggingface.co/spaces/ResembleAI/Chatterbox)              | [Listen](https://resemble-ai.github.io/chatterbox_demopage/) |
+| Model                                                           | Size     | Languages   | Key Features                                            | Best For                                     | 🤗                                                                           | Examples                                                           |
+| :-------------------------------------------------------------- | :------- | :---------- | :------------------------------------------------------ | :------------------------------------------- | :--------------------------------------------------------------------------- | :----------------------------------------------------------------- |
+| **Chatterbox-Turbo**                                            | **350M** | **English** | Paralinguistic Tags (`[laugh]`), Lower Compute and VRAM | Zero-shot voice agents, Production           | [Demo](https://huggingface.co/spaces/ResembleAI/chatterbox-turbo-demo)       | [Listen](https://resemble-ai.github.io/chatterbox_turbo_demopage/) |
+| Chatterbox-Multilingual [(Language list)](#supported-languages) | 500M     | 23+         | Zero-shot cloning, Multiple Languages                   | Global applications, Localization            | [Demo](https://huggingface.co/spaces/ResembleAI/Chatterbox-Multilingual-TTS) | [Listen](https://resemble-ai.github.io/chatterbox_demopage/)       |
+| Chatterbox [(Tips and Tricks)](#original-chatterbox-tips)       | 500M     | English     | CFG & Exaggeration tuning                               | General zero-shot TTS with creative controls | [Demo](https://huggingface.co/spaces/ResembleAI/Chatterbox)                  | [Listen](https://resemble-ai.github.io/chatterbox_demopage/)       |
 
 ## Installation
+
 ```shell
 pip install chatterbox-tts
 ```
 
 Alternatively, you can install from source:
+
 ```shell
 # conda create -yn chatterbox python=3.11
 # conda activate chatterbox
@@ -44,6 +45,7 @@ git clone https://github.com/resemble-ai/chatterbox.git
 cd chatterbox
 pip install -e .
 ```
+
 We developed and tested Chatterbox on Python 3.11 on Debian 11 OS; the versions of the dependencies are pinned in `pyproject.toml` to ensure consistency. You can modify the code or dependencies in this installation mode.
 
 ## Usage
@@ -83,10 +85,10 @@ wav = model.generate(text)
 ta.save("test-english.wav", wav, model.sr)
 
 # Multilingual examples
-multilingual_model = ChatterboxMultilingualTTS.from_pretrained(device=device)
+multilingual_model = ChatterboxMultilingualTTS.from_pretrained(device="cuda")
 
 french_text = "Bonjour, comment ça va? Ceci est le modèle de synthèse vocale multilingue Chatterbox, il prend en charge 23 langues."
-wav_french = multilingual_model.generate(spanish_text, language_id="fr")
+wav_french = multilingual_model.generate(french_text, language_id="fr")
 ta.save("test-french.wav", wav_french, model.sr)
 
 chinese_text = "你好，今天天气真不错，希望你有一个愉快的周末。"
@@ -98,12 +100,15 @@ AUDIO_PROMPT_PATH = "YOUR_FILE.wav"
 wav = model.generate(text, audio_prompt_path=AUDIO_PROMPT_PATH)
 ta.save("test-2.wav", wav, model.sr)
 ```
+
 See `example_tts.py` and `example_vc.py` for more examples.
 
-## Supported Languages 
+## Supported Languages
+
 Arabic (ar) • Danish (da) • German (de) • Greek (el) • English (en) • Spanish (es) • Finnish (fi) • French (fr) • Hebrew (he) • Hindi (hi) • Italian (it) • Japanese (ja) • Korean (ko) • Malay (ms) • Dutch (nl) • Norwegian (no) • Polish (pl) • Portuguese (pt) • Russian (ru) • Swedish (sv) • Swahili (sw) • Turkish (tr) • Chinese (zh)
 
 ## Original Chatterbox Tips
+
 - **General Use (TTS and Voice Agents):**
   - Ensure that the reference clip matches the specified language tag. Otherwise, language transfer outputs may inherit the accent of the reference clip’s language. To mitigate this, set `cfg_weight` to `0`.
   - The default settings (`exaggeration=0.5`, `cfg_weight=0.5`) work well for most prompts across all languages.
@@ -113,11 +118,9 @@ Arabic (ar) • Danish (da) • German (de) • Greek (el) • English (en) • 
   - Try lower `cfg_weight` values (e.g. `~0.3`) and increase `exaggeration` to around `0.7` or higher.
   - Higher `exaggeration` tends to speed up speech; reducing `cfg_weight` helps compensate with slower, more deliberate pacing.
 
-
 ## Built-in PerTh Watermarking for Responsible AI
 
 Every audio file generated by Chatterbox includes [Resemble AI's Perth (Perceptual Threshold) Watermarker](https://github.com/resemble-ai/perth) - imperceptible neural watermarks that survive MP3 compression, audio editing, and common manipulations while maintaining nearly 100% detection accuracy.
-
 
 ## Watermark extraction
 
@@ -141,12 +144,12 @@ print(f"Extracted watermark: {watermark}")
 # Output: 0.0 (no watermark) or 1.0 (watermarked)
 ```
 
-
 ## Official Discord
 
 👋 Join us on [Discord](https://discord.gg/rJq9cRJBJ6) and let's build something awesome together!
 
 ## Acknowledgements
+
 - [Cosyvoice](https://github.com/FunAudioLLM/CosyVoice)
 - [Real-Time-Voice-Cloning](https://github.com/CorentinJ/Real-Time-Voice-Cloning)
 - [HiFT-GAN](https://github.com/yl4579/HiFTNet)
@@ -154,7 +157,9 @@ print(f"Extracted watermark: {watermark}")
 - [S3Tokenizer](https://github.com/xingchensong/S3Tokenizer)
 
 ## Citation
+
 If you find this model useful, please consider citing.
+
 ```
 @misc{chatterboxtts2025,
   author       = {{Resemble AI}},
@@ -164,5 +169,7 @@ If you find this model useful, please consider citing.
   note         = {GitHub repository}
 }
 ```
+
 ## Disclaimer
+
 Don't use this model to do bad things. Prompts are sourced from freely available data on the internet.


### PR DESCRIPTION
### What this PR fixes
- Fixes a typo in README multilingual example where `spanish_text` was used instead of `french_text`
- Prevents NameError when users copy the example
- (Optional) Clarifies device variable usage

This is a documentation-only change.
