### PR TITLE
Fix: Alignment stream analyzer added a new forward hook for each utterance

### DIFF
--- a/src/chatterbox/models/t3/inference/alignment_stream_analyzer.py
+++ b/src/chatterbox/models/t3/inference/alignment_stream_analyzer.py
@@ -64,6 +64,26 @@ class AlignmentStreamAnalyzer:
             self.last_aligned_attns += [None]
             self._add_attention_spy(tfmr, i, layer_idx, head_idx)
 
+    def reset(self, text_tokens_slice):
+        """
+        Resets the internal state for a new utterance.
+        """
+        self.text_tokens_slice = (i, j) = text_tokens_slice
+        self.alignment = torch.zeros(0, j-i)
+        self.curr_frame_pos = 0
+        self.text_position = 0
+
+        self.started = False
+        self.started_at = None
+
+        self.complete = False
+        self.completed_at = None
+
+        # Track generated tokens for repetition detection
+        self.generated_tokens = []
+
+        self.last_aligned_attns = [None] * len(LLAMA_ALIGNED_HEADS)
+
     def _add_attention_spy(self, tfmr, buffer_idx, layer_idx, head_idx):
         """
         Adds a forward hook to a specific attention layer to collect outputs.

--- a/src/chatterbox/models/t3/t3.py
+++ b/src/chatterbox/models/t3/t3.py
@@ -270,8 +270,6 @@ class T3(nn.Module):
         # In order to use the standard HF generate method, we need to extend some methods to inject our custom logic
         # Note the llama-specific logic. Other tfmr types can be added later.
 
-        self.compiled = False
-
         # TODO? synchronize the expensive compile function
         # with self.compile_lock:
         if not self.compiled:
@@ -296,6 +294,10 @@ class T3(nn.Module):
             )
             self.patched_model = patched_model
             self.compiled = True
+        else:
+            self.patched_model.alignment_stream_analyzer.reset(
+                text_tokens_slice=(len_cond, len_cond + text_tokens.size(-1)),
+            )
 
         # # Run normal generate method, which calls our custom extended methods
         # return self.patched_model.generate(


### PR DESCRIPTION
A new instance of the alignment stream analyzer is currently being instantiated for each call of `T3.inference`: https://github.com/resemble-ai/chatterbox/blob/ed27b95ee46b95be201147bafe5ca85ac57ac4f2/src/chatterbox/models/t3/t3.py#L273-L288

Hence, each time a new forward hook is added to the backbone's self-attention layers. When generating multiple utterances, this will eventually slow down the generation. After 1000 utterances, the attention masks will be copied 1000 times from GPU to CPU when running on CUDA. This affects the multilingual model since the alignment stream analyzer is enabled by default for it, see, for example, #352.

This PR changes the logic so that the alignment stream analyzer is only instantiated once, and its internal state is instead reset for each utterance without adding new forward hooks to the backbone model.

I tested the fix by generating ~8500 short utterances, which now takes ~4.5h instead of ~50h on my setup.

A big thanks to @benHeid for pointing out the issue in #352! 😊