### PR TITLE
build(pyproject): modernize license metadata and add package build CI check

### DIFF
--- a/.github/workflows/install_check.yml
+++ b/.github/workflows/install_check.yml
@@ -21,3 +21,8 @@ jobs:
     - name: Test Standard Install
       run: |
         pip install -e .
+
+    - name: Build Packages
+      run: |
+        pip install build
+        python -m build --sdist --wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.6"
 description = "Chatterbox: Open Source TTS and Voice Conversion by Resemble AI"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {file = "LICENSE"}
+license = "MIT"
 authors = [
     {name = "resemble-ai", email = "engineering@resemble.ai"}
 ]


### PR DESCRIPTION
## Summary
- modernize `pyproject.toml` license metadata
- add package build verification in CI
- keep changes scoped to packaging/release hygiene

## Validation
- `python -m build --sdist --wheel`