### PR TITLE
docs: fix README device variable and multilingual example text

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,14 @@ ta.save("test-turbo.wav", wav, model.sr)
 ```python
 
 import torchaudio as ta
+import torch
 from chatterbox.tts import ChatterboxTTS
 from chatterbox.mtl_tts import ChatterboxMultilingualTTS
 
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
 # English example
-model = ChatterboxTTS.from_pretrained(device="cuda")
+model = ChatterboxTTS.from_pretrained(device=device)
 
 text = "Ezreal and Jinx teamed up with Ahri, Yasuo, and Teemo to take down the enemy's Nexus in an epic late-game pentakill."
 wav = model.generate(text)
@@ -86,12 +89,12 @@ ta.save("test-english.wav", wav, model.sr)
 multilingual_model = ChatterboxMultilingualTTS.from_pretrained(device=device)
 
 french_text = "Bonjour, comment ça va? Ceci est le modèle de synthèse vocale multilingue Chatterbox, il prend en charge 23 langues."
-wav_french = multilingual_model.generate(spanish_text, language_id="fr")
-ta.save("test-french.wav", wav_french, model.sr)
+wav_french = multilingual_model.generate(french_text, language_id="fr")
+ta.save("test-french.wav", wav_french, multilingual_model.sr)
 
 chinese_text = "你好，今天天气真不错，希望你有一个愉快的周末。"
 wav_chinese = multilingual_model.generate(chinese_text, language_id="zh")
-ta.save("test-chinese.wav", wav_chinese, model.sr)
+ta.save("test-chinese.wav", wav_chinese, multilingual_model.sr)
 
 # If you want to synthesize with a different voice, specify the audio prompt
 AUDIO_PROMPT_PATH = "YOUR_FILE.wav"


### PR DESCRIPTION
Fix README usage examples:
- define device (cpu/cuda)
- use french_text instead of an undefined spanish_text when generating French audio
- use multilingual_model.sr when saving multilingual outputs

Fixes #444 and #448.