### PR TITLE
fix: add map_location to torch.load in multilingual model for CPU/MPS…

### DIFF
--- a/src/chatterbox/mtl_tts.py
+++ b/src/chatterbox/mtl_tts.py
@@ -161,9 +161,15 @@ class ChatterboxMultilingualTTS:
     def from_local(cls, ckpt_dir, device) -> 'ChatterboxMultilingualTTS':
         ckpt_dir = Path(ckpt_dir)
 
+        # Always load to CPU first for non-CUDA devices to handle CUDA-saved models
+        if device in ["cpu", "mps"]:
+            map_location = torch.device('cpu')
+        else:
+            map_location = None
+
         ve = VoiceEncoder()
         ve.load_state_dict(
-            torch.load(ckpt_dir / "ve.pt", weights_only=True)
+            torch.load(ckpt_dir / "ve.pt", weights_only=True, map_location=map_location)
         )
         ve.to(device).eval()
 
@@ -176,7 +182,7 @@ class ChatterboxMultilingualTTS:
 
         s3gen = S3Gen()
         s3gen.load_state_dict(
-            torch.load(ckpt_dir / "s3gen.pt", weights_only=True)
+            torch.load(ckpt_dir / "s3gen.pt", weights_only=True, map_location=map_location)
         )
         s3gen.to(device).eval()
 
@@ -186,7 +192,7 @@ class ChatterboxMultilingualTTS:
 
         conds = None
         if (builtin_voice := ckpt_dir / "conds.pt").exists():
-            conds = Conditionals.load(builtin_voice).to(device)
+            conds = Conditionals.load(builtin_voice, map_location=map_location).to(device)
 
         return cls(t3, s3gen, ve, tokenizer, device, conds=conds)
 


### PR DESCRIPTION
## Fix: Multilingual model broken on CPU/MPS

Fixes #351

### Problem
`ChatterboxMultilingualTTS.from_local()` calls `torch.load()` without 
`map_location`, causing a `RuntimeError` when loading CUDA-saved weights 
on a CPU-only or MPS machine.

### Fix
Added `map_location=torch.device('cpu')` for non-CUDA devices, matching 
the pattern already used in [tts.py](cci:7://file:///C:/Users/Arthur/chatterbox/test_tts.py:0:0-0:0)'s `ChatterboxTTS.from_local()`.

### Changes
- [src/chatterbox/mtl_tts.py](cci:7://file:///C:/Users/Arthur/chatterbox/src/chatterbox/mtl_tts.py:0:0-0:0): Added `map_location` to `torch.load` 
  calls for `ve.pt`, `s3gen.pt`, and `conds.pt`