### PR TITLE
fix: add map_location to torch.load calls for CPU compatibility

### DIFF
--- a/src/chatterbox/mtl_tts.py
+++ b/src/chatterbox/mtl_tts.py
@@ -163,7 +163,7 @@ class ChatterboxMultilingualTTS:
 
         ve = VoiceEncoder()
         ve.load_state_dict(
-            torch.load(ckpt_dir / "ve.pt", weights_only=True)
+            torch.load(ckpt_dir / "ve.pt", weights_only=True, map_location=device)
         )
         ve.to(device).eval()
 
@@ -176,7 +176,7 @@ class ChatterboxMultilingualTTS:
 
         s3gen = S3Gen()
         s3gen.load_state_dict(
-            torch.load(ckpt_dir / "s3gen.pt", weights_only=True)
+            torch.load(ckpt_dir / "s3gen.pt", weights_only=True, map_location=device)
         )
         s3gen.to(device).eval()
 


### PR DESCRIPTION
## Description

This PR fixes issue #472 by adding `map_location=device` parameter to `torch.load()` calls in the `from_local()` method.

## Problem

When loading models on CPU devices, PyTorch throws an error because it cannot load CUDA-trained models directly to CPU without specifying the map_location parameter.

## Changes

- Added `map_location=device` to `torch.load()` for `ve.pt` (line 166)
- Added `map_location=device` to `torch.load()` for `s3gen.pt` (line 179)

## Testing

Created a test script (`test_cpu_loading.py`) that verifies all `torch.load()` calls in `mtl_tts.py` include the `map_location` parameter.

## Related Issues

Fixes #472

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are minimal and focused
- [x] Test added to verify the fix
- [ ] Tests pass locally (no existing test suite)