### PR TITLE
fix: prevent promotion to float64 in ChatterboxTurboTTS.norm_loudness

### DIFF
--- a/src/chatterbox/tts_turbo.py
+++ b/src/chatterbox/tts_turbo.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import librosa
 import torch
 import perth
+import numpy as np
 import pyloudnorm as ln
 
 from safetensors.torch import load_file
@@ -206,7 +207,7 @@ class ChatterboxTurboTTS:
             meter = ln.Meter(sr)
             loudness = meter.integrated_loudness(wav)
             gain_db = target_lufs - loudness
-            gain_linear = 10.0 ** (gain_db / 20.0)
+            gain_linear = np.float32(10.0 ** (gain_db / 20.0))
             if math.isfinite(gain_linear) and gain_linear > 0.0:
                 wav = wav * gain_linear
         except Exception as e:


### PR DESCRIPTION
Closes #499 which causes speech generation to fail in ChatterboxTurboTTS when numpy==2.* is installed.

Problem: a numpy array representing the prompt audio gets promoted from float32 to float64, due to the new promotion rules and it being multiplied by a float64 scalar

Fix: cast the scalar to float32 before multiplying