### PR TITLE
fix: remove forward-hook leak in AlignmentStreamAnalyzer

### DIFF
--- a/src/chatterbox/models/t3/inference/alignment_stream_analyzer.py
+++ b/src/chatterbox/models/t3/inference/alignment_stream_analyzer.py
@@ -47,6 +47,13 @@ class AlignmentStreamAnalyzer:
         self.curr_frame_pos = 0
         self.text_position = 0
 
+        # Track the transformer and any state we mutate so `close()` can undo it.
+        self._tfmr = tfmr
+        self._hook_handles = []
+        self._config_patched = False
+        self._original_output_attentions = None
+        self._original_attn_implementation = None
+
         self.started = False
         self.started_at = None
 
@@ -80,14 +87,45 @@ class AlignmentStreamAnalyzer:
                 self.last_aligned_attns[buffer_idx] = step_attention[0, head_idx]  # (T0, Ti)
 
         target_layer = tfmr.layers[layer_idx].self_attn
-        # Register hook and store the handle
-        target_layer.register_forward_hook(attention_forward_hook)
-        if hasattr(tfmr, 'config') and hasattr(tfmr.config, 'output_attentions'):
-            self.original_output_attentions = tfmr.config.output_attentions
-            self.original_attn_implementation = getattr(tfmr.config, '_attn_implementation', None)
+        # Register hook and store the handle so it can be removed in `close()`.
+        handle = target_layer.register_forward_hook(attention_forward_hook)
+        self._hook_handles.append(handle)
+        if not self._config_patched and hasattr(tfmr, 'config') and hasattr(tfmr.config, 'output_attentions'):
+            self._original_output_attentions = tfmr.config.output_attentions
+            self._original_attn_implementation = getattr(tfmr.config, '_attn_implementation', None)
             if getattr(tfmr.config, '_attn_implementation', None) == 'sdpa':
                 tfmr.config._attn_implementation = 'eager'
             tfmr.config.output_attentions = True
+            self._config_patched = True
+
+    def close(self):
+        """
+        Remove all registered forward hooks and restore any transformer config
+        values that were mutated during construction. Safe to call multiple
+        times.
+        """
+        while self._hook_handles:
+            handle = self._hook_handles.pop()
+            try:
+                handle.remove()
+            except Exception:
+                pass
+        if self._config_patched:
+            tfmr = self._tfmr
+            if tfmr is not None and hasattr(tfmr, 'config'):
+                try:
+                    tfmr.config.output_attentions = self._original_output_attentions
+                    if self._original_attn_implementation is not None:
+                        tfmr.config._attn_implementation = self._original_attn_implementation
+                except Exception:
+                    pass
+            self._config_patched = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
 
     def step(self, logits, next_token=None):
         """

--- a/src/chatterbox/models/t3/t3.py
+++ b/src/chatterbox/models/t3/t3.py
@@ -274,142 +274,150 @@ class T3(nn.Module):
 
         # TODO? synchronize the expensive compile function
         # with self.compile_lock:
-        if not self.compiled:
-            # Default to None for English models, only create for multilingual
-            alignment_stream_analyzer = None
-            if self.hp.is_multilingual:
-                alignment_stream_analyzer = AlignmentStreamAnalyzer(
-                    self.tfmr,
-                    None,
-                    text_tokens_slice=(len_cond, len_cond + text_tokens.size(-1)),
-                    alignment_layer_idx=9, # TODO: hparam or something?
-                    eos_idx=self.hp.stop_speech_token,
+        alignment_stream_analyzer = None
+        try:
+            if not self.compiled:
+                # Default to None for English models, only create for multilingual
+                alignment_stream_analyzer = None
+                if self.hp.is_multilingual:
+                    alignment_stream_analyzer = AlignmentStreamAnalyzer(
+                        self.tfmr,
+                        None,
+                        text_tokens_slice=(len_cond, len_cond + text_tokens.size(-1)),
+                        alignment_layer_idx=9, # TODO: hparam or something?
+                        eos_idx=self.hp.stop_speech_token,
+                    )
+                    assert alignment_stream_analyzer.eos_idx == self.hp.stop_speech_token
+
+                patched_model = T3HuggingfaceBackend(
+                    config=self.cfg,
+                    llama=self.tfmr,
+                    speech_enc=self.speech_emb,
+                    speech_head=self.speech_head,
+                    alignment_stream_analyzer=alignment_stream_analyzer,
                 )
-                assert alignment_stream_analyzer.eos_idx == self.hp.stop_speech_token
+                self.patched_model = patched_model
+                self.compiled = True
 
-            patched_model = T3HuggingfaceBackend(
-                config=self.cfg,
-                llama=self.tfmr,
-                speech_enc=self.speech_emb,
-                speech_head=self.speech_head,
-                alignment_stream_analyzer=alignment_stream_analyzer,
-            )
-            self.patched_model = patched_model
-            self.compiled = True
+            # # Run normal generate method, which calls our custom extended methods
+            # return self.patched_model.generate(
+            #     inputs=initial_speech_tokens,
+            #     decoder_cond=embeds,
+            #     bos_token_id=self.hp.start_speech_token,
+            #     eos_token_id=(self.hp.stop_speech_token if stop_on_eos else -1),
+            #     pad_token_id=self.hp.stop_speech_token,
+            #     max_new_tokens=max_new_tokens or self.hp.max_speech_tokens,
+            #     num_return_sequences=num_return_sequences,
+            #     temperature=temperature,
+            #     min_p=min_p,
+            #     length_penalty=length_penalty,
+            #     repetition_penalty=repetition_penalty,
+            #     do_sample=do_sample,
+            #     # cache_implementation=None if not self.compiled else "static",
+            # )
 
-        # # Run normal generate method, which calls our custom extended methods
-        # return self.patched_model.generate(
-        #     inputs=initial_speech_tokens,
-        #     decoder_cond=embeds,
-        #     bos_token_id=self.hp.start_speech_token,
-        #     eos_token_id=(self.hp.stop_speech_token if stop_on_eos else -1),
-        #     pad_token_id=self.hp.stop_speech_token,
-        #     max_new_tokens=max_new_tokens or self.hp.max_speech_tokens,
-        #     num_return_sequences=num_return_sequences,
-        #     temperature=temperature,
-        #     min_p=min_p,
-        #     length_penalty=length_penalty,
-        #     repetition_penalty=repetition_penalty,
-        #     do_sample=do_sample,
-        #     # cache_implementation=None if not self.compiled else "static",
-        # )
+            device = embeds.device
 
-        device = embeds.device
+            bos_token = torch.tensor([[self.hp.start_speech_token]], dtype=torch.long, device=device)
+            bos_embed = self.speech_emb(bos_token)  # shape: (B, 1, embed_dim)
+            bos_embed = bos_embed + self.speech_pos_emb.get_fixed_embedding(0)
 
-        bos_token = torch.tensor([[self.hp.start_speech_token]], dtype=torch.long, device=device)
-        bos_embed = self.speech_emb(bos_token)  # shape: (B, 1, embed_dim)
-        bos_embed = bos_embed + self.speech_pos_emb.get_fixed_embedding(0)
+            # batch_size=2 for CFG
+            bos_embed = torch.cat([bos_embed, bos_embed])
 
-        # batch_size=2 for CFG
-        bos_embed = torch.cat([bos_embed, bos_embed])
+            # Combine condition and BOS token for the initial input
+            inputs_embeds = torch.cat([embeds, bos_embed], dim=1)
 
-        # Combine condition and BOS token for the initial input
-        inputs_embeds = torch.cat([embeds, bos_embed], dim=1)
+            # Track generated token ids; start with the BOS token.
+            generated_ids = bos_token.clone()
+            predicted = []  # To store the predicted tokens
 
-        # Track generated token ids; start with the BOS token.
-        generated_ids = bos_token.clone()
-        predicted = []  # To store the predicted tokens
+            # Instantiate the logits processors.
+            top_p_warper = TopPLogitsWarper(top_p=top_p)
+            min_p_warper = MinPLogitsWarper(min_p=min_p)
+            top_p_warper = TopPLogitsWarper(top_p=top_p)
+            repetition_penalty_processor = RepetitionPenaltyLogitsProcessor(penalty=float(repetition_penalty))
 
-        # Instantiate the logits processors.
-        top_p_warper = TopPLogitsWarper(top_p=top_p)
-        min_p_warper = MinPLogitsWarper(min_p=min_p)
-        top_p_warper = TopPLogitsWarper(top_p=top_p)
-        repetition_penalty_processor = RepetitionPenaltyLogitsProcessor(penalty=float(repetition_penalty))
-
-        # ---- Initial Forward Pass (no kv_cache yet) ----
-        output = self.patched_model(
-            inputs_embeds=inputs_embeds,
-            past_key_values=None,
-            use_cache=True,
-            output_attentions=True,
-            output_hidden_states=True,
-            return_dict=True,
-        )
-        # Initialize kv_cache with the full context.
-        past = output.past_key_values
-
-        # ---- Generation Loop using kv_cache ----
-        for i in tqdm(range(max_new_tokens), desc="Sampling", dynamic_ncols=True):
-            logits_step = output.logits[:, -1, :]
-            # CFG combine  → (1, V)
-            cond   = logits_step[0:1, :]
-            uncond = logits_step[1:2, :]
-            cfg = torch.as_tensor(cfg_weight, device=cond.device, dtype=cond.dtype)
-            logits = cond + cfg * (cond - uncond)
-            
-            # Apply alignment stream analyzer integrity checks
-            if self.patched_model.alignment_stream_analyzer is not None:
-                if logits.dim() == 1:            # guard in case something upstream squeezed
-                    logits = logits.unsqueeze(0) # (1, V)
-                # Pass the last generated token for repetition tracking
-                last_token = generated_ids[0, -1].item() if len(generated_ids[0]) > 0 else None
-                logits = self.patched_model.alignment_stream_analyzer.step(logits, next_token=last_token)  # (1, V)
-
-            # Apply repetition penalty
-            ids_for_proc = generated_ids[:1, ...]   # batch = 1
-            logits = repetition_penalty_processor(ids_for_proc, logits)  # expects (B,V)
-            
-            # Apply temperature scaling.
-            if temperature != 1.0:
-                logits = logits / temperature
-                
-            # Apply min_p and top_p filtering
-            logits = min_p_warper(ids_for_proc, logits)
-            logits = top_p_warper(ids_for_proc, logits)
-
-            # Convert logits to probabilities and sample the next token.
-            probs = torch.softmax(logits, dim=-1)
-            next_token = torch.multinomial(probs, num_samples=1)  # shape: (B, 1)
-
-            predicted.append(next_token)
-            generated_ids = torch.cat([generated_ids, next_token], dim=1)
-
-            # Check for EOS token.
-            if next_token.view(-1) == self.hp.stop_speech_token:
-                logger.info(f"✅ EOS token detected! Stopping generation at step {i+1}")
-                break
-
-            # Get embedding for the new token.
-            next_token_embed = self.speech_emb(next_token)
-            next_token_embed = next_token_embed + self.speech_pos_emb.get_fixed_embedding(i + 1)
-
-            #  For CFG
-            next_token_embed = torch.cat([next_token_embed, next_token_embed])
-
-            # Forward pass with only the new token and the cached past.
+            # ---- Initial Forward Pass (no kv_cache yet) ----
             output = self.patched_model(
-                inputs_embeds=next_token_embed,
-                past_key_values=past,
+                inputs_embeds=inputs_embeds,
+                past_key_values=None,
+                use_cache=True,
                 output_attentions=True,
                 output_hidden_states=True,
                 return_dict=True,
             )
-            # Update the kv_cache.
+            # Initialize kv_cache with the full context.
             past = output.past_key_values
 
-        # Concatenate all predicted tokens along the sequence dimension.
-        predicted_tokens = torch.cat(predicted, dim=1)  # shape: (B, num_tokens)
-        return predicted_tokens
+            # ---- Generation Loop using kv_cache ----
+            for i in tqdm(range(max_new_tokens), desc="Sampling", dynamic_ncols=True):
+                logits_step = output.logits[:, -1, :]
+                # CFG combine  → (1, V)
+                cond   = logits_step[0:1, :]
+                uncond = logits_step[1:2, :]
+                cfg = torch.as_tensor(cfg_weight, device=cond.device, dtype=cond.dtype)
+                logits = cond + cfg * (cond - uncond)
+
+                # Apply alignment stream analyzer integrity checks
+                if self.patched_model.alignment_stream_analyzer is not None:
+                    if logits.dim() == 1:            # guard in case something upstream squeezed
+                        logits = logits.unsqueeze(0) # (1, V)
+                    # Pass the last generated token for repetition tracking
+                    last_token = generated_ids[0, -1].item() if len(generated_ids[0]) > 0 else None
+                    logits = self.patched_model.alignment_stream_analyzer.step(logits, next_token=last_token)  # (1, V)
+
+                # Apply repetition penalty
+                ids_for_proc = generated_ids[:1, ...]   # batch = 1
+                logits = repetition_penalty_processor(ids_for_proc, logits)  # expects (B,V)
+
+                # Apply temperature scaling.
+                if temperature != 1.0:
+                    logits = logits / temperature
+
+                # Apply min_p and top_p filtering
+                logits = min_p_warper(ids_for_proc, logits)
+                logits = top_p_warper(ids_for_proc, logits)
+
+                # Convert logits to probabilities and sample the next token.
+                probs = torch.softmax(logits, dim=-1)
+                next_token = torch.multinomial(probs, num_samples=1)  # shape: (B, 1)
+
+                predicted.append(next_token)
+                generated_ids = torch.cat([generated_ids, next_token], dim=1)
+
+                # Check for EOS token.
+                if next_token.view(-1) == self.hp.stop_speech_token:
+                    logger.info(f"✅ EOS token detected! Stopping generation at step {i+1}")
+                    break
+
+                # Get embedding for the new token.
+                next_token_embed = self.speech_emb(next_token)
+                next_token_embed = next_token_embed + self.speech_pos_emb.get_fixed_embedding(i + 1)
+
+                #  For CFG
+                next_token_embed = torch.cat([next_token_embed, next_token_embed])
+
+                # Forward pass with only the new token and the cached past.
+                output = self.patched_model(
+                    inputs_embeds=next_token_embed,
+                    past_key_values=past,
+                    output_attentions=True,
+                    output_hidden_states=True,
+                    return_dict=True,
+                )
+                # Update the kv_cache.
+                past = output.past_key_values
+
+            # Concatenate all predicted tokens along the sequence dimension.
+            predicted_tokens = torch.cat(predicted, dim=1)  # shape: (B, num_tokens)
+            return predicted_tokens
+        finally:
+            # Always release forward hooks and restore tfmr config, even on
+            # exception, so repeated calls to `inference()` do not accumulate
+            # hooks on the underlying transformer layers.
+            if alignment_stream_analyzer is not None:
+                alignment_stream_analyzer.close()
 
     @torch.inference_mode()
     def inference_turbo(self, t3_cond, text_tokens, temperature=0.8, top_k=1000, top_p=0.95, repetition_penalty=1.2,


### PR DESCRIPTION
## Summary

- **Store `RemovableHandle`s** returned by `register_forward_hook` so they can be cleaned up
- **Guard config mutation** with `_config_patched` flag so repeated analyzer construction cannot overwrite the true original `output_attentions` / `_attn_implementation` values
- **Add `close()` method** that removes all hooks and restores config (also implements `__enter__`/`__exit__`)
- **Wrap `T3.inference()` body** in `try/finally` so `close()` runs even on exception

## Problem

Each `ChatterboxMultilingualTTS.generate()` call creates a new `AlignmentStreamAnalyzer` that registers 3 forward hooks on the transformer's attention layers but never removes them. After N calls, 3×N stale hooks accumulate, all closing over earlier analyzer instances whose `last_aligned_attns` buffers still update on every forward pass. This corrupts the alignment matrix fed to the EOS heuristics.

**macOS (CPU/MPS)** — audio collapses to ~0.4s after call 1:
```
Call 1: duration= 18.42s  hooks=1
Call 2: duration=  0.40s  hooks=2
```

**Windows 11, RTX 3080 Ti, CUDA** — hooks grow monotonically, forced EOS triggers on every call:
```
Call 1: duration=  4.64s  hooks=33
Call 2: duration=  4.84s  hooks=36
Call 3: duration=  4.52s  hooks=39
```

After this fix, hook count stays constant across all calls.

See #504 for the full root cause analysis, minimal reproducer, and end-user workaround.

## Test plan

- [x] Ran minimal reproducer (5 consecutive `generate()` calls) on Windows/CUDA — hook count stays at 30 (pre-existing model hooks only, no growth)
- [x] Verified on macOS CPU/MPS (prior testing)
- [x] Verified on Linux CUDA (prior testing)
- [x] Confirmed English-only `ChatterboxTTS` path is unaffected (analyzer never constructed)