### PR TITLE
fix: cast tensors to float32 for MPS (Apple Silicon) compatibility

### DIFF
--- a/src/chatterbox/models/s3tokenizer/s3tokenizer.py
+++ b/src/chatterbox/models/s3tokenizer/s3tokenizer.py
@@ -83,6 +83,7 @@ class S3Tokenizer(S3TokenizerV2):
                 wav = torch.from_numpy(wav)
             if wav.dim() == 1:
                 wav = wav.unsqueeze(0)
+            wav = wav.float()  # ensure float32; MPS doesn't support float64
 
             processed_wavs.append(wav)
         return processed_wavs

--- a/src/chatterbox/models/voice_encoder/voice_encoder.py
+++ b/src/chatterbox/models/voice_encoder/voice_encoder.py
@@ -239,7 +239,7 @@ class VoiceEncoder(nn.Module):
 
         # Embed them
         with torch.inference_mode():
-            utt_embeds = self.inference(mels.to(self.device), mel_lens, batch_size=batch_size, **kwargs).numpy()
+            utt_embeds = self.inference(mels.float().to(self.device), mel_lens, batch_size=batch_size, **kwargs).numpy()
 
         return self.utt_to_spk_embed(utt_embeds) if as_spk else utt_embeds
 


### PR DESCRIPTION
## Summary

- `torch.from_numpy()` preserves numpy's default `float64` dtype, but MPS (Apple Silicon GPU) does not support `float64` at all — it raises a `TypeError` when the tensor is moved to the MPS device.
- This fix adds `.float()` (i.e. cast to `float32`) at the two affected sites.

## Changes

**`src/chatterbox/models/s3tokenizer/s3tokenizer.py`** — `_prepare_audio()`
```python
# before
wav = torch.from_numpy(wav)
# after
wav = torch.from_numpy(wav)
wav = wav.float()  # ensure float32; MPS doesn't support float64
```

**`src/chatterbox/models/voice_encoder/voice_encoder.py`** — `embeds_from_mels()`
```python
# before
utt_embeds = self.inference(mels.to(self.device), ...)
# after
utt_embeds = self.inference(mels.float().to(self.device), ...)
```

## Error reproduced (before fix)

Running `example_tts_turbo.py` on Apple Silicon with `device="mps"` raised:

```
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64. Please use float32 instead.
```

The same error surfaced in both `s3tokenizer.py` (during `prepare_conditionals`) and `voice_encoder.py` (during `embeds_from_mels`).

## Tested on

- Apple M-series (MPS backend)
- Python 3.13 / PyTorch with MPS support