### PR TITLE
feat: add Telugu language support to multilingual TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ ta.save("test-2.wav", wav, model.sr)
 See `example_tts.py` and `example_vc.py` for more examples.
 
 ## Supported Languages
-Arabic (ar) • Danish (da) • German (de) • Greek (el) • English (en) • Spanish (es) • Finnish (fi) • French (fr) • Hebrew (he) • Hindi (hi) • Italian (it) • Japanese (ja) • Korean (ko) • Malay (ms) • Dutch (nl) • Norwegian (no) • Polish (pl) • Portuguese (pt) • Russian (ru) • Swedish (sv) • Swahili (sw) • Turkish (tr) • Chinese (zh)
+Arabic (ar) • Danish (da) • German (de) • Greek (el) • English (en) • Spanish (es) • Finnish (fi) • French (fr) • Hebrew (he) • Hindi (hi) • Italian (it) • Japanese (ja) • Korean (ko) • Malay (ms) • Dutch (nl) • Norwegian (no) • Polish (pl) • Portuguese (pt) • Russian (ru) • Swedish (sv) • Swahili (sw) • Telugu (te) • Turkish (tr) • Chinese (zh)
 
 ## Original Chatterbox Tips
 - **General Use (TTS and Voice Agents):**

--- a/multilingual_app.py
+++ b/multilingual_app.py
@@ -98,6 +98,9 @@ LANGUAGE_CONFIG = {
         "audio": "https://storage.googleapis.com/chatterbox-demo-samples/mtl_prompts/sw_m.flac",
         "text": "Mwezi uliopita, tulifika hatua mpya ya maoni ya bilioni mbili kweny kituo chetu cha YouTube."
     },
+    "te": {
+        "text": "గత నెలలో మన యూట్యూబ్ చానల్‌లో రెండు బిలియన్ వీక్షణలతో కొత్త మైలురాయి సాధించాం.",
+    },
     "tr": {
         "audio": "https://storage.googleapis.com/chatterbox-demo-samples/mtl_prompts/tr_m.flac",
         "text": "Geçen ay YouTube kanalımızda iki milyar görüntüleme ile yeni bir dönüm noktasına ulaştık."
@@ -122,12 +125,12 @@ def get_supported_languages_display() -> str:
     language_items = []
     for code, name in sorted(SUPPORTED_LANGUAGES.items()):
         language_items.append(f"**{name}** (`{code}`)")
-    
+
     # Split into 2 lines
     mid = len(language_items) // 2
     line1 = " • ".join(language_items[:mid])
     line2 = " • ".join(language_items[mid:])
-    
+
     return f"""
 ### 🌍 Supported Languages ({len(SUPPORTED_LANGUAGES)} total)
 {line1}
@@ -166,7 +169,7 @@ def set_seed(seed: int):
         torch.cuda.manual_seed_all(seed)
     random.seed(seed)
     np.random.seed(seed)
-    
+
 def resolve_audio_prompt(language_id: str, provided_path: str | None) -> str | None:
     """
     Decide which audio prompt to use:
@@ -190,9 +193,9 @@ def generate_tts_audio(
     """
     Generate high-quality speech audio from text using Chatterbox Multilingual model with optional reference audio styling.
     Supported languages: English, French, German, Spanish, Italian, Portuguese, and Hindi.
-    
-    This tool synthesizes natural-sounding speech from input text. When a reference audio file 
-    is provided, it captures the speaker's voice characteristics and speaking style. The generated audio 
+
+    This tool synthesizes natural-sounding speech from input text. When a reference audio file
+    is provided, it captures the speaker's voice characteristics and speaking style. The generated audio
     maintains the prosody, tone, and vocal qualities of the reference speaker, or uses default voice if no reference is provided.
 
     Args:
@@ -202,7 +205,7 @@ def generate_tts_audio(
         exaggeration_input (float, optional): Controls speech expressiveness (0.25-2.0, neutral=0.5, extreme values may be unstable). Defaults to 0.5.
         temperature_input (float, optional): Controls randomness in generation (0.05-5.0, higher=more varied). Defaults to 0.8.
         seed_num_input (int, optional): Random seed for reproducible results (0 for random generation). Defaults to 0.
-        cfgw_input (float, optional): CFG/Pace weight controlling generation guidance (0.2-1.0). Defaults to 0.5, 0 for language transfer. 
+        cfgw_input (float, optional): CFG/Pace weight controlling generation guidance (0.2-1.0). Defaults to 0.5, 0 for language transfer.
 
     Returns:
         tuple[int, np.ndarray]: A tuple containing the sample rate (int) and the generated audio waveform (numpy.ndarray)
@@ -216,7 +219,7 @@ def generate_tts_audio(
         set_seed(int(seed_num_input))
 
     print(f"Generating audio for text: '{text_input[:50]}...'")
-    
+
     # Handle optional audio prompt
     chosen_prompt = audio_prompt_path_input or default_audio_for_ui(language_id)
 
@@ -230,7 +233,7 @@ def generate_tts_audio(
         print(f"Using audio prompt: {chosen_prompt}")
     else:
         print("No audio prompt provided; using default voice.")
-        
+
     wav = current_model.generate(
         text_input[:300],  # Truncate text to max chars
         language_id=language_id,
@@ -246,7 +249,7 @@ with gr.Blocks() as demo:
         Generate high-quality multilingual speech from text with reference audio styling, supporting 23 languages.
         """
     )
-    
+
     # Display supported languages
     gr.Markdown(get_supported_languages_display())
     with gr.Row():
@@ -257,26 +260,26 @@ with gr.Blocks() as demo:
                 label="Text to synthesize (max chars 300)",
                 max_lines=5
             )
-            
+
             language_id = gr.Dropdown(
                 choices=list(ChatterboxMultilingualTTS.get_supported_languages().keys()),
                 value=initial_lang,
                 label="Language",
                 info="Select the language for text-to-speech synthesis"
             )
-            
+
             ref_wav = gr.Audio(
                 sources=["upload", "microphone"],
                 type="filepath",
                 label="Reference Audio File (Optional)",
                 value=default_audio_for_ui(initial_lang)
             )
-            
+
             gr.Markdown(
                 "💡 **Note**: Ensure that the reference clip matches the specified language tag. Otherwise, language transfer outputs may inherit the accent of the reference clip's language. To mitigate this, set the CFG weight to 0.",
                 elem_classes=["audio-note"]
             )
-            
+
             exaggeration = gr.Slider(
                 0.25, 2, step=.05, label="Exaggeration (Neutral = 0.5, extreme values can be unstable)", value=.5
             )

--- a/multilingual_app.py
+++ b/multilingual_app.py
@@ -99,7 +99,7 @@ LANGUAGE_CONFIG = {
         "text": "Mwezi uliopita, tulifika hatua mpya ya maoni ya bilioni mbili kweny kituo chetu cha YouTube."
     },
     "te": {
-        "text": "గత నెలలో మన యూట్యూబ్ చానల్‌లో రెండు బిలియన్ వీక్షణలతో కొత్త మైలురాయి సాధించాం.",
+        "text": "గత నెలలో మన యూట్యూబ్ చానల్‌‌లో రెండు బిలియన్ వీక్షణలతో కొత్త మైలురాయి సాధించాం.",
     },
     "tr": {
         "audio": "https://storage.googleapis.com/chatterbox-demo-samples/mtl_prompts/tr_m.flac",
@@ -125,12 +125,12 @@ def get_supported_languages_display() -> str:
     language_items = []
     for code, name in sorted(SUPPORTED_LANGUAGES.items()):
         language_items.append(f"**{name}** (`{code}`)")
-
+    
     # Split into 2 lines
     mid = len(language_items) // 2
     line1 = " • ".join(language_items[:mid])
     line2 = " • ".join(language_items[mid:])
-
+    
     return f"""
 ### 🌍 Supported Languages ({len(SUPPORTED_LANGUAGES)} total)
 {line1}
@@ -169,7 +169,7 @@ def set_seed(seed: int):
         torch.cuda.manual_seed_all(seed)
     random.seed(seed)
     np.random.seed(seed)
-
+    
 def resolve_audio_prompt(language_id: str, provided_path: str | None) -> str | None:
     """
     Decide which audio prompt to use:
@@ -193,9 +193,9 @@ def generate_tts_audio(
     """
     Generate high-quality speech audio from text using Chatterbox Multilingual model with optional reference audio styling.
     Supported languages: English, French, German, Spanish, Italian, Portuguese, and Hindi.
-
-    This tool synthesizes natural-sounding speech from input text. When a reference audio file
-    is provided, it captures the speaker's voice characteristics and speaking style. The generated audio
+    
+    This tool synthesizes natural-sounding speech from input text. When a reference audio file 
+    is provided, it captures the speaker's voice characteristics and speaking style. The generated audio 
     maintains the prosody, tone, and vocal qualities of the reference speaker, or uses default voice if no reference is provided.
 
     Args:
@@ -205,7 +205,7 @@ def generate_tts_audio(
         exaggeration_input (float, optional): Controls speech expressiveness (0.25-2.0, neutral=0.5, extreme values may be unstable). Defaults to 0.5.
         temperature_input (float, optional): Controls randomness in generation (0.05-5.0, higher=more varied). Defaults to 0.8.
         seed_num_input (int, optional): Random seed for reproducible results (0 for random generation). Defaults to 0.
-        cfgw_input (float, optional): CFG/Pace weight controlling generation guidance (0.2-1.0). Defaults to 0.5, 0 for language transfer.
+        cfgw_input (float, optional): CFG/Pace weight controlling generation guidance (0.2-1.0). Defaults to 0.5, 0 for language transfer. 
 
     Returns:
         tuple[int, np.ndarray]: A tuple containing the sample rate (int) and the generated audio waveform (numpy.ndarray)
@@ -219,7 +219,7 @@ def generate_tts_audio(
         set_seed(int(seed_num_input))
 
     print(f"Generating audio for text: '{text_input[:50]}...'")
-
+    
     # Handle optional audio prompt
     chosen_prompt = audio_prompt_path_input or default_audio_for_ui(language_id)
 
@@ -233,7 +233,7 @@ def generate_tts_audio(
         print(f"Using audio prompt: {chosen_prompt}")
     else:
         print("No audio prompt provided; using default voice.")
-
+        
     wav = current_model.generate(
         text_input[:300],  # Truncate text to max chars
         language_id=language_id,
@@ -249,7 +249,7 @@ with gr.Blocks() as demo:
         Generate high-quality multilingual speech from text with reference audio styling, supporting 23 languages.
         """
     )
-
+    
     # Display supported languages
     gr.Markdown(get_supported_languages_display())
     with gr.Row():
@@ -260,26 +260,26 @@ with gr.Blocks() as demo:
                 label="Text to synthesize (max chars 300)",
                 max_lines=5
             )
-
+            
             language_id = gr.Dropdown(
                 choices=list(ChatterboxMultilingualTTS.get_supported_languages().keys()),
                 value=initial_lang,
                 label="Language",
                 info="Select the language for text-to-speech synthesis"
             )
-
+            
             ref_wav = gr.Audio(
                 sources=["upload", "microphone"],
                 type="filepath",
                 label="Reference Audio File (Optional)",
                 value=default_audio_for_ui(initial_lang)
             )
-
+            
             gr.Markdown(
                 "💡 **Note**: Ensure that the reference clip matches the specified language tag. Otherwise, language transfer outputs may inherit the accent of the reference clip's language. To mitigate this, set the CFG weight to 0.",
                 elem_classes=["audio-note"]
             )
-
+            
             exaggeration = gr.Slider(
                 0.25, 2, step=.05, label="Exaggeration (Neutral = 0.5, extreme values can be unstable)", value=.5
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "safetensors==0.5.3",
     "spacy-pkuseg",
     "pykakasi==2.3.0",
+    "indic-transliteration",
     "gradio==6.8.0",
     "pyloudnorm",
     "omegaconf"

--- a/src/chatterbox/models/tokenizers/tokenizer.py
+++ b/src/chatterbox/models/tokenizers/tokenizer.py
@@ -75,15 +75,15 @@ def is_katakana(c: str) -> bool:
 def hiragana_normalize(text: str) -> str:
     """Japanese text normalization: converts kanji to hiragana; katakana remains the same."""
     global _kakasi
-
+    
     try:
         if _kakasi is None:
             import pykakasi
             _kakasi = pykakasi.kakasi()
-
+        
         result = _kakasi.convert(text)
         out = []
-
+        
         for r in result:
             inp = r['orig']
             hira = r["hira"]
@@ -100,15 +100,15 @@ def hiragana_normalize(text: str) -> str:
 
             else:
                 out.append(inp)
-
+        
         normalized_text = "".join(out)
-
+        
         # Decompose Japanese characters for tokenizer compatibility
         import unicodedata
         normalized_text = unicodedata.normalize('NFKD', normalized_text)
-
+        
         return normalized_text
-
+        
     except ImportError:
         logger.warning("pykakasi not available - Japanese text processing skipped")
         return text
@@ -117,14 +117,14 @@ def hiragana_normalize(text: str) -> str:
 def add_hebrew_diacritics(text: str) -> str:
     """Hebrew text normalization: adds diacritics to Hebrew text."""
     global _dicta
-
+    
     try:
         if _dicta is None:
             from dicta_onnx import Dicta
             _dicta = Dicta()
-
+        
         return _dicta.add_diacritics(text)
-
+        
     except ImportError:
         logger.warning("dicta_onnx not available - Hebrew text processing skipped")
         return text
@@ -135,47 +135,47 @@ def add_hebrew_diacritics(text: str) -> str:
 
 def korean_normalize(text: str) -> str:
     """Korean text normalization: decompose syllables into Jamo for tokenization."""
-
+    
     def decompose_hangul(char):
         """Decompose Korean syllable into Jamo components."""
         if not ('\uac00' <= char <= '\ud7af'):
             return char
-
+        
         # Hangul decomposition formula
         base = ord(char) - 0xAC00
         initial = chr(0x1100 + base // (21 * 28))
         medial = chr(0x1161 + (base % (21 * 28)) // 28)
         final = chr(0x11A7 + base % 28) if base % 28 > 0 else ''
-
+        
         return initial + medial + final
-
+    
     # Decompose syllables and normalize punctuation
-    result = ''.join(decompose_hangul(char) for char in text)
+    result = ''.join(decompose_hangul(char) for char in text)    
     return result.strip()
 
 
 class ChineseCangjieConverter:
     """Converts Chinese characters to Cangjie codes for tokenization."""
-
+    
     def __init__(self, model_dir=None):
         self.word2cj = {}
         self.cj2word = {}
         self.segmenter = None
         self._load_cangjie_mapping(model_dir)
         self._init_segmenter()
-
+    
     def _load_cangjie_mapping(self, model_dir=None):
-        """Load Cangjie mapping from HuggingFace model repository."""
+        """Load Cangjie mapping from HuggingFace model repository."""        
         try:
             cangjie_file = hf_hub_download(
                 repo_id=REPO_ID,
                 filename="Cangjie5_TC.json",
                 cache_dir=model_dir
             )
-
+            
             with open(cangjie_file, "r", encoding="utf-8") as fp:
                 data = json.load(fp)
-
+            
             for entry in data:
                 word, code = entry.split("\t")[:2]
                 self.word2cj[word] = code
@@ -183,10 +183,10 @@ class ChineseCangjieConverter:
                     self.cj2word[code] = [word]
                 else:
                     self.cj2word[code].append(word)
-
+                    
         except Exception as e:
             logger.warning(f"Could not load Cangjie mapping: {e}")
-
+    
     def _init_segmenter(self):
         """Initialize pkuseg segmenter."""
         try:
@@ -195,7 +195,7 @@ class ChineseCangjieConverter:
         except ImportError:
             logger.warning("pkuseg not available - Chinese segmentation will be skipped")
             self.segmenter = None
-
+    
     def _cangjie_encode(self, glyph: str):
         """Encode a single Chinese glyph to Cangjie code."""
         normed_glyph = glyph
@@ -205,9 +205,9 @@ class ChineseCangjieConverter:
         index = self.cj2word[code].index(normed_glyph)
         index = str(index) if index > 0 else ""
         return code + str(index)
+    
 
-
-
+    
     def __call__(self, text):
         """Convert Chinese characters in text to Cangjie tokens."""
         output = []
@@ -216,7 +216,7 @@ class ChineseCangjieConverter:
             full_text = " ".join(segmented_words)
         else:
             full_text = text
-
+        
         for t in full_text:
             if category(t) == "Lo":
                 cangjie = self._cangjie_encode(t)
@@ -251,14 +251,14 @@ def telugu_to_latin(text: str) -> str:
 def add_russian_stress(text: str) -> str:
     """Russian text normalization: adds stress marks to Russian text."""
     global _russian_stresser
-
+    
     try:
         if _russian_stresser is None:
             from russian_text_stresser.text_stresser import RussianTextStresser
             _russian_stresser = RussianTextStresser()
-
+        
         return _russian_stresser.stress_text(text)
-
+        
     except ImportError:
         logger.warning("russian_text_stresser not available - Russian stress labeling skipped")
         return text
@@ -288,7 +288,7 @@ class MTLTokenizer:
             preprocessed_text = preprocessed_text.lower()
         if nfkd_normalize:
             preprocessed_text = normalize("NFKD", preprocessed_text)
-
+        
         return preprocessed_text
 
     def text_to_tokens(self, text: str, language_id: str = None, lowercase: bool = True, nfkd_normalize: bool = True):
@@ -298,7 +298,7 @@ class MTLTokenizer:
 
     def encode(self, txt: str, language_id: str = None, lowercase: bool = True, nfkd_normalize: bool = True):
         txt = self.preprocess_text(txt, language_id=language_id, lowercase=lowercase, nfkd_normalize=nfkd_normalize)
-
+        
         # Language-specific text processing
         if language_id == 'zh':
             txt = self.cangjie_converter(txt)
@@ -312,11 +312,11 @@ class MTLTokenizer:
             txt = add_russian_stress(txt)
         elif language_id == 'te':
             txt = telugu_to_latin(txt)
-
+        
         # Prepend language token
         if language_id:
             txt = f"[{language_id.lower()}]{txt}"
-
+        
         txt = txt.replace(' ', SPACE)
         return self.tokenizer.encode(txt).ids
 

--- a/src/chatterbox/models/tokenizers/tokenizer.py
+++ b/src/chatterbox/models/tokenizers/tokenizer.py
@@ -75,15 +75,15 @@ def is_katakana(c: str) -> bool:
 def hiragana_normalize(text: str) -> str:
     """Japanese text normalization: converts kanji to hiragana; katakana remains the same."""
     global _kakasi
-    
+
     try:
         if _kakasi is None:
             import pykakasi
             _kakasi = pykakasi.kakasi()
-        
+
         result = _kakasi.convert(text)
         out = []
-        
+
         for r in result:
             inp = r['orig']
             hira = r["hira"]
@@ -100,15 +100,15 @@ def hiragana_normalize(text: str) -> str:
 
             else:
                 out.append(inp)
-        
+
         normalized_text = "".join(out)
-        
+
         # Decompose Japanese characters for tokenizer compatibility
         import unicodedata
         normalized_text = unicodedata.normalize('NFKD', normalized_text)
-        
+
         return normalized_text
-        
+
     except ImportError:
         logger.warning("pykakasi not available - Japanese text processing skipped")
         return text
@@ -117,14 +117,14 @@ def hiragana_normalize(text: str) -> str:
 def add_hebrew_diacritics(text: str) -> str:
     """Hebrew text normalization: adds diacritics to Hebrew text."""
     global _dicta
-    
+
     try:
         if _dicta is None:
             from dicta_onnx import Dicta
             _dicta = Dicta()
-        
+
         return _dicta.add_diacritics(text)
-        
+
     except ImportError:
         logger.warning("dicta_onnx not available - Hebrew text processing skipped")
         return text
@@ -135,47 +135,47 @@ def add_hebrew_diacritics(text: str) -> str:
 
 def korean_normalize(text: str) -> str:
     """Korean text normalization: decompose syllables into Jamo for tokenization."""
-    
+
     def decompose_hangul(char):
         """Decompose Korean syllable into Jamo components."""
         if not ('\uac00' <= char <= '\ud7af'):
             return char
-        
+
         # Hangul decomposition formula
         base = ord(char) - 0xAC00
         initial = chr(0x1100 + base // (21 * 28))
         medial = chr(0x1161 + (base % (21 * 28)) // 28)
         final = chr(0x11A7 + base % 28) if base % 28 > 0 else ''
-        
+
         return initial + medial + final
-    
+
     # Decompose syllables and normalize punctuation
-    result = ''.join(decompose_hangul(char) for char in text)    
+    result = ''.join(decompose_hangul(char) for char in text)
     return result.strip()
 
 
 class ChineseCangjieConverter:
     """Converts Chinese characters to Cangjie codes for tokenization."""
-    
+
     def __init__(self, model_dir=None):
         self.word2cj = {}
         self.cj2word = {}
         self.segmenter = None
         self._load_cangjie_mapping(model_dir)
         self._init_segmenter()
-    
+
     def _load_cangjie_mapping(self, model_dir=None):
-        """Load Cangjie mapping from HuggingFace model repository."""        
+        """Load Cangjie mapping from HuggingFace model repository."""
         try:
             cangjie_file = hf_hub_download(
                 repo_id=REPO_ID,
                 filename="Cangjie5_TC.json",
                 cache_dir=model_dir
             )
-            
+
             with open(cangjie_file, "r", encoding="utf-8") as fp:
                 data = json.load(fp)
-            
+
             for entry in data:
                 word, code = entry.split("\t")[:2]
                 self.word2cj[word] = code
@@ -183,10 +183,10 @@ class ChineseCangjieConverter:
                     self.cj2word[code] = [word]
                 else:
                     self.cj2word[code].append(word)
-                    
+
         except Exception as e:
             logger.warning(f"Could not load Cangjie mapping: {e}")
-    
+
     def _init_segmenter(self):
         """Initialize pkuseg segmenter."""
         try:
@@ -195,7 +195,7 @@ class ChineseCangjieConverter:
         except ImportError:
             logger.warning("pkuseg not available - Chinese segmentation will be skipped")
             self.segmenter = None
-    
+
     def _cangjie_encode(self, glyph: str):
         """Encode a single Chinese glyph to Cangjie code."""
         normed_glyph = glyph
@@ -205,9 +205,9 @@ class ChineseCangjieConverter:
         index = self.cj2word[code].index(normed_glyph)
         index = str(index) if index > 0 else ""
         return code + str(index)
-    
 
-    
+
+
     def __call__(self, text):
         """Convert Chinese characters in text to Cangjie tokens."""
         output = []
@@ -216,7 +216,7 @@ class ChineseCangjieConverter:
             full_text = " ".join(segmented_words)
         else:
             full_text = text
-        
+
         for t in full_text:
             if category(t) == "Lo":
                 cangjie = self._cangjie_encode(t)
@@ -234,17 +234,31 @@ class ChineseCangjieConverter:
         return "".join(output)
 
 
+def telugu_to_latin(text: str) -> str:
+    """Telugu text normalization: transliterate Telugu script to IAST Latin phonetic representation."""
+    try:
+        from indic_transliteration import sanscript
+        from indic_transliteration.sanscript import transliterate
+        return transliterate(text, sanscript.TELUGU, sanscript.IAST)
+    except ImportError:
+        logger.warning("indic_transliteration not available - Telugu text processing skipped")
+        return text
+    except Exception as e:
+        logger.warning(f"Telugu transliteration failed: {e}")
+        return text
+
+
 def add_russian_stress(text: str) -> str:
     """Russian text normalization: adds stress marks to Russian text."""
     global _russian_stresser
-    
+
     try:
         if _russian_stresser is None:
             from russian_text_stresser.text_stresser import RussianTextStresser
             _russian_stresser = RussianTextStresser()
-        
+
         return _russian_stresser.stress_text(text)
-        
+
     except ImportError:
         logger.warning("russian_text_stresser not available - Russian stress labeling skipped")
         return text
@@ -274,7 +288,7 @@ class MTLTokenizer:
             preprocessed_text = preprocessed_text.lower()
         if nfkd_normalize:
             preprocessed_text = normalize("NFKD", preprocessed_text)
-        
+
         return preprocessed_text
 
     def text_to_tokens(self, text: str, language_id: str = None, lowercase: bool = True, nfkd_normalize: bool = True):
@@ -284,7 +298,7 @@ class MTLTokenizer:
 
     def encode(self, txt: str, language_id: str = None, lowercase: bool = True, nfkd_normalize: bool = True):
         txt = self.preprocess_text(txt, language_id=language_id, lowercase=lowercase, nfkd_normalize=nfkd_normalize)
-        
+
         # Language-specific text processing
         if language_id == 'zh':
             txt = self.cangjie_converter(txt)
@@ -296,11 +310,13 @@ class MTLTokenizer:
             txt = korean_normalize(txt)
         elif language_id == 'ru':
             txt = add_russian_stress(txt)
-        
+        elif language_id == 'te':
+            txt = telugu_to_latin(txt)
+
         # Prepend language token
         if language_id:
             txt = f"[{language_id.lower()}]{txt}"
-        
+
         txt = txt.replace(' ', SPACE)
         return self.tokenizer.encode(txt).ids
 

--- a/src/chatterbox/mtl_tts.py
+++ b/src/chatterbox/mtl_tts.py
@@ -250,7 +250,7 @@ class ChatterboxMultilingualTTS:
             )
         )
         return cls.from_local(ckpt_dir, device, t3_model=t3_model)
-
+    
     def prepare_conditionals(self, wav_fpath, exaggeration=0.5):
         ## Load reference wav
         s3gen_ref_wav, _sr = librosa.load(wav_fpath, sr=S3GEN_SR)
@@ -297,7 +297,7 @@ class ChatterboxMultilingualTTS:
                 f"Unsupported language_id '{language_id}'. "
                 f"Supported languages: {supported_langs}"
             )
-
+        
         if audio_prompt_path:
             self.prepare_conditionals(audio_prompt_path, exaggeration=exaggeration)
         else:

--- a/src/chatterbox/mtl_tts.py
+++ b/src/chatterbox/mtl_tts.py
@@ -50,6 +50,7 @@ SUPPORTED_LANGUAGES = {
   "ru": "Russian",
   "sv": "Swedish",
   "sw": "Swahili",
+  "te": "Telugu",
   "tr": "Turkish",
   "zh": "Chinese",
 }
@@ -249,7 +250,7 @@ class ChatterboxMultilingualTTS:
             )
         )
         return cls.from_local(ckpt_dir, device, t3_model=t3_model)
-    
+
     def prepare_conditionals(self, wav_fpath, exaggeration=0.5):
         ## Load reference wav
         s3gen_ref_wav, _sr = librosa.load(wav_fpath, sr=S3GEN_SR)
@@ -296,7 +297,7 @@ class ChatterboxMultilingualTTS:
                 f"Unsupported language_id '{language_id}'. "
                 f"Supported languages: {supported_langs}"
             )
-        
+
         if audio_prompt_path:
             self.prepare_conditionals(audio_prompt_path, exaggeration=exaggeration)
         else:


### PR DESCRIPTION
## Summary

- Add `"te": "Telugu"` to `SUPPORTED_LANGUAGES` in `mtl_tts.py`
- Add `telugu_to_latin()` in `tokenizer.py` using `indic-transliteration` (IAST scheme) to convert Telugu script → Latin phoneme representation for tokenization, mirroring the kanji→hiragana (Japanese) and syllable→Jamo (Korean) patterns already in the codebase
- Add `indic-transliteration` as a package dependency in `pyproject.toml`
- Add Telugu sample text and `LANGUAGE_CONFIG` entry in `multilingual_app.py`

## Approach

Telugu is a Brahmic abugida script. Since the current multilingual model was trained on 23 languages (not including Telugu), the tokenizer normalizes Telugu input via IAST transliteration — converting native script to Latin phoneme sequences the model can recognize. This is consistent with how other scripts are handled (e.g. kanji→hiragana, Hangul syllable decomposition).

When a Telugu-trained checkpoint becomes available, the `telugu_to_latin()` step can be removed and the native script will be tokenized directly.

## Test plan

- [ ] Install `indic-transliteration` and verify `pip install -e .` succeeds
- [ ] Run `ChatterboxMultilingualTTS.get_supported_languages()` and confirm `"te": "Telugu"` is present
- [ ] Call `model.generate("నమస్కారం.", language_id="te", audio_prompt_path="ref.wav")` and verify no errors
- [ ] Verify `generate()` raises `ValueError` for unsupported language codes (regression)
- [ ] Confirm Gradio app shows Telugu in language dropdown with sample text pre-filled