### PR TITLE
Port T3 backbone to MLX with performance improvements and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ assets/*.npz
 # Virtual environments
 venv*/
 .venv*/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,10 @@ checkpoints/
 
 # Ignore generated sample .wav files
 **/*.wav
+
+# Ignore pre-converted MLX weights (generated from source safetensors)
+assets/*.npz
+
+# Virtual environments
+venv*/
+.venv*/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,24 @@
+# Chatterbox TTS — Domain Context
+
+## Project
+Chatterbox is an open-source TTS (text-to-speech) and voice cloning system by Resemble AI. It uses a three-stage architecture: a voice encoder (speaker embedding), a T3 autoregressive transformer (text→speech tokens), and an S3Gen decoder (speech tokens→mel→audio).
+
+## Key Components
+
+| Term | Description |
+|---|---|
+| **T3** | Autoregressive transformer (520M LLaMA-3-style) that generates speech tokens from text + conditioning |
+| **S3Gen** | Flow-matching decoder that converts speech tokens to audio waveform (24kHz output) |
+| **VoiceEncoder** | Extracts speaker embeddings from reference audio (256-dim vectors) |
+| **S3Tokenizer** | Converts audio ↔ speech tokens at 25 tokens/sec |
+| **Perceiver** | Cross-attention resampler that compresses 150 reference speech tokens into 32 |
+
+## Generation Pipeline
+1. `prepare_conditionals`: load reference audio → extract speaker embedding + speech prompt tokens
+2. `prepare_conditioning`: project speaker emb + compress prompt via Perceiver
+3. `forward`: concat [cond_emb, text_emb, speech_emb] → LLaMA backbone → logits
+4. Autoregressive loop: sample one speech token at a time, feed back as next input
+5. `S3Gen.inference`: decode speech tokens → waveform
+
+## MLX Port (feat/mlx-port)
+The T3 backbone (steps 3-4) is ported to MLX for Metal-native inference on Apple Silicon. Conditioning (steps 1-2) and audio decoding (step 5) remain in PyTorch.

--- a/docs/adr/0001-mlx-port-boundary.md
+++ b/docs/adr/0001-mlx-port-boundary.md
@@ -1,0 +1,32 @@
+# ADR-0001: MLX Port Boundary
+
+**Status:** Accepted
+**Date:** 2026-06-21
+
+## Context
+
+The T3 model's autoregressive speech token generation is the bottleneck (~15-22 tok/s on MPS vs the 25 tok/s needed for real-time). We need to accelerate it using MLX, Apple's Metal-native ML framework.
+
+The T3 pipeline has four stages:
+1. **Conditioning encoder** — VoiceEncoder + Perceiver resampler + speaker embedding projection (runs once per generation)
+2. **Embedding tables** — text, speech, and position embeddings
+3. **LLaMA backbone** — 30-layer decoder-only transformer (~95% of compute)
+4. **Speech head** — linear projection to vocabulary logits
+
+## Decision
+
+Port stages 2, 3, and 4 (embeddings + backbone + speech head) to MLX. Stage 1 (conditioning encoder) remains in PyTorch.
+
+The data flow across the boundary:
+```
+PyTorch → T3CondEnc → cond_emb (numpy)  
+                    → text_tokens → text_emb (MLX)
+                    → speech_tokens → speech_emb (MLX)
+                    → [cond | text | speech] → LLaMA backbone (MLX) → speech_head (MLX) → logits
+```
+
+## Consequences
+
+- **Positive**: The conditioning encoder is trivial complexity to keep in PyTorch (<50 lines of glue code). No MLX porting effort for the Perceiver or speaker encoder. The compute bottleneck (backbone) is fully on Metal.
+- **Negative**: One numpy bridge copy between PyTorch and MLX per generation (negligible — 34×1024 float32 array). The conditioning encoder runs on PyTorch MPS in parallel with MLX device, but since it's a single forward pass this doesn't matter.
+- **Reversal cost**: Low — the boundary is just a single array transfer point. Reversing (porting more to MLX) is equally easy.

--- a/docs/adr/0002-backbone-construction-strategy.md
+++ b/docs/adr/0002-backbone-construction-strategy.md
@@ -1,0 +1,28 @@
+# ADR-0002: Backbone Construction Strategy
+
+**Status:** Accepted  
+**Date:** 2026-06-21
+
+## Context
+
+The T3 backbone is a LLaMA-3-style decoder-only transformer: RMSNorm → RoPE-attention → RMSNorm → SwiGLU-MLP × 30 layers. MLX provides `nn.TransformerDecoderLayer` but it uses LayerNorm + standard FFN, which doesn't match LLaMA's architecture.
+
+## Decision
+
+Build the LLaMA decoder layer manually from MLX primitives rather than using or subclassing `nn.TransformerDecoderLayer`.
+
+The layer is constructed from:
+- `nn.RMSNorm` — pre-attention and pre-FFN normalisation
+- `nn.Linear` × 4 — Q, K, V projections (1024→1024) and output projection (1024→1024)
+- `nn.RoPE(dims=64, base=500000.0)` — applied to Q and K after projection
+- `mx.fast.scaled_dot_product_attention` — with causal mask and scale=1/√64
+- `nn.Linear` × 3 — SwiGLU MLP (gate_proj + up_proj 1024→4096, down_proj 4096→1024)
+- `nn.SiLU` — activation for SwiGLU gate
+
+KV cache stored as `past_k, past_v` tuples per layer, passed explicitly in the autoregressive loop.
+
+## Consequences
+
+- **Positive**: Full control over RoPE application point. Matches PyTorch LLaMA exactly. No workarounds for API impedance mismatches.
+- **Negative**: ~100 lines of layer code vs 1 line for `nn.TransformerDecoderLayer`. But this is boilerplate that any LLaMA port needs anyway.
+- **Reversal cost**: Low — the layer is self-contained. If MLX later adds LLaMA support, replacing the manual layer is a swap.

--- a/docs/adr/0003-weight-conversion-strategy.md
+++ b/docs/adr/0003-weight-conversion-strategy.md
@@ -1,0 +1,42 @@
+# ADR-0003: Weight Conversion Strategy
+
+**Status:** Accepted  
+**Date:** 2026-06-21
+
+## Context
+
+The T3 model weights are distributed as HuggingFace safetensors files (`.safetensors`). MLX requires its own array format. We need a conversion strategy that works for both offline (saved `.npz` checkpoint) and online (direct load) use cases.
+
+## Decision
+
+Load safetensors with PyTorch, then convert each tensor to `mx.array` and build the MLX model's state dict by key-name mapping.
+
+Key mapping convention (PyTorch → MLX):
+```
+tfmr.layers.{n}.self_attn.q_proj.weight → model.layers.{n}.attention.q_proj.weight
+tfmr.layers.{n}.self_attn.k_proj.weight → model.layers.{n}.attention.k_proj.weight
+tfmr.layers.{n}.self_attn.v_proj.weight → model.layers.{n}.attention.v_proj.weight
+tfmr.layers.{n}.self_attn.o_proj.weight → model.layers.{n}.attention.o_proj.weight
+tfmr.layers.{n}.input_layernorm.weight  → model.layers.{n}.attention_norm.weight
+tfmr.layers.{n}.post_attention_layernorm.weight → model.layers.{n}.ffn_norm.weight
+tfmr.layers.{n}.mlp.gate_proj.weight    → model.layers.{n}.mlp.gate.weight
+tfmr.layers.{n}.mlp.up_proj.weight      → model.layers.{n}.mlp.up.weight
+tfmr.layers.{n}.mlp.down_proj.weight    → model.layers.{n}.mlp.down.weight
+tfmr.norm.weight                         → model.norm.weight
+speech_emb.weight                        → model.speech_emb.weight
+speech_head.weight                       → model.speech_head.weight
+text_emb.weight                          → model.text_emb.weight
+text_head.weight                         → model.text_head.weight
+speech_pos_emb.emb.weight                → model.speech_pos_emb.weight
+text_pos_emb.emb.weight                  → model.text_pos_emb.weight
+```
+
+Non-ported weights (remain in PyTorch, not loaded into MLX):
+- `cond_enc.*` — stays in PyTorch
+- `tfmr.embed_tokens.weight` — unused in T3 (model passes `inputs_embeds`, not token IDs)
+
+## Consequences
+
+- **Positive**: Direct key-name mapping is simple, auditable, and reversible. No custom serialization format. Works with any safetensors checkpoint.
+- **Negative**: Requires both PyTorch and MLX installed. Adds ~100ms load time for the PyTorch→MLX conversion. Acceptable for a PoC.
+- **Reversal cost**: Low — the conversion is a one-way script. Switching to pure MLX loading (numpy `.npz` format) would be a day's work.

--- a/docs/adr/0004-poc-scope-reduction.md
+++ b/docs/adr/0004-poc-scope-reduction.md
@@ -1,0 +1,29 @@
+# ADR-0004: PoC Scope Reduction
+
+**Status:** Accepted  
+**Date:** 2026-06-21
+
+## Context
+
+The T3 model includes several peripheral components that contribute minimal compute cost. For a proof-of-concept focused on backbone speed, porting these is pure overhead.
+
+## Decision
+
+Port the minimal subset needed for a meaningful speed benchmark:
+
+| Component | Decision | Rationale |
+|---|---|---|
+| **Perceiver resampler** | Skip | Runs once per generation, not per token. Keep in PyTorch, pass cond_emb as numpy array. |
+| **CFG (classifier-free guidance)** | Skip | `cfg_weight=0` for PoC. Standard T3 `inference_turbo` already skips it. |
+| **Emotion conditioning** | Skip | `emotion_adv` is a scalar → 1024 linear. Trivial to add later if needed. |
+| **CLAP embedding** | Skip | Always None in current code. Dead code path. |
+| **Text logit head** | Skip | Only needed for training. PoC is inference-only. |
+| **Top-p / min-p sampling** | Include | Needed for quality output. ~20 lines. |
+| **Repetition penalty** | Include | Needed for quality output. ~5 lines. |
+| **KV cache** | Include | Critical for performance. Without it, attention cost is O(n²) per step. |
+
+## Consequences
+
+- **Positive**: PoC code is focused on the bottleneck. ~350 lines instead of ~600+. Faster time to benchmark.
+- **Negative**: Can't test full end-to-end audio without PyTorch glue. PoC benchmark measures tokens/sec, not audio output.
+- **Reversal cost**: Low — each skipped component is self-contained. Adding them later doesn't require refactoring.

--- a/docs/adr/0005-success-criteria.md
+++ b/docs/adr/0005-success-criteria.md
@@ -1,0 +1,21 @@
+# ADR-0005: Success Criteria
+
+**Status:** Accepted  
+**Date:** 2026-06-21
+
+## Context
+
+Without a clear definition of "success," the PoC has no termination condition.
+
+## Decision
+
+| Metric | Threshold | Method |
+|---|---|---|
+| **Generation speed** | ≥25 tok/s (1× real-time) | Average over 3 runs of 200-token generation, warm cache |
+| **Output correctness** | Logit MSE < 1e-2 vs PyTorch baseline | Single forward pass, same random seed |
+| **Drop-in compatibility** | MLX-generated speech tokens → PyTorch S3Gen produces audible speech | Subjective: no obvious artifacts |
+
+## Consequences
+
+- **Positive**: Clear go/no-go for the MLX approach. If MLX achieves ≥25 tok/s, the approach is viable; if <15 tok/s, it's not worth the porting complexity.
+- **Negative**: None — objective criteria.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
     "omegaconf"
 ]
 
+[project.optional-dependencies]
+mlx = ["mlx>=0.31.0"]
+
 [project.urls]
 Homepage = "https://github.com/resemble-ai/chatterbox"
 Repository = "https://github.com/resemble-ai/chatterbox"

--- a/scripts/convert_weights_mlx.py
+++ b/scripts/convert_weights_mlx.py
@@ -1,0 +1,87 @@
+"""Convert T3 safetensors to MLX-compatible .npz weights."""
+import os, sys
+from pathlib import Path
+import numpy as np
+import mlx.core as mx
+from safetensors.torch import load_file
+
+KEY_MAP = {}
+for i in range(30):
+    KEY_MAP[f"tfmr.layers.{i}.self_attn.q_proj.weight"] = f"layers.{i}.attention.q_proj.weight"
+    KEY_MAP[f"tfmr.layers.{i}.self_attn.k_proj.weight"] = f"layers.{i}.attention.k_proj.weight"
+    KEY_MAP[f"tfmr.layers.{i}.self_attn.v_proj.weight"] = f"layers.{i}.attention.v_proj.weight"
+    KEY_MAP[f"tfmr.layers.{i}.self_attn.o_proj.weight"] = f"layers.{i}.attention.o_proj.weight"
+    KEY_MAP[f"tfmr.layers.{i}.input_layernorm.weight"] = f"layers.{i}.attention_norm.weight"
+    KEY_MAP[f"tfmr.layers.{i}.post_attention_layernorm.weight"] = f"layers.{i}.ffn_norm.weight"
+    KEY_MAP[f"tfmr.layers.{i}.mlp.gate_proj.weight"] = f"layers.{i}.mlp.gate.weight"
+    KEY_MAP[f"tfmr.layers.{i}.mlp.up_proj.weight"] = f"layers.{i}.mlp.up.weight"
+    KEY_MAP[f"tfmr.layers.{i}.mlp.down_proj.weight"] = f"layers.{i}.mlp.down.weight"
+
+KEY_MAP.update({
+    "tfmr.norm.weight": "norm.weight",
+    "speech_emb.weight": "speech_emb.weight",
+    "speech_head.weight": "speech_head.weight",
+    "text_emb.weight": "text_emb.weight",
+    "text_head.weight": "text_head.weight",
+    "speech_pos_emb.emb.weight": "speech_pos_emb.weight",
+    "text_pos_emb.emb.weight": "text_pos_emb.weight",
+    "cond_enc.spkr_enc.weight": "cond_enc_spkr.weight",
+    "cond_enc.spkr_enc.bias": "cond_enc_spkr.bias",
+    "cond_enc.emotion_adv_fc.weight": "cond_enc_emotion_fc.weight",
+    "cond_enc.perceiver.pre_attention_query": "perceiver_query",
+    "cond_enc.perceiver.attn.to_q.weight": "perceiver_to_q.weight",
+    "cond_enc.perceiver.attn.to_q.bias": "perceiver_to_q.bias",
+    "cond_enc.perceiver.attn.to_k.weight": "perceiver_to_k.weight",
+    "cond_enc.perceiver.attn.to_k.bias": "perceiver_to_k.bias",
+    "cond_enc.perceiver.attn.to_v.weight": "perceiver_to_v.weight",
+    "cond_enc.perceiver.attn.to_v.bias": "perceiver_to_v.bias",
+    "cond_enc.perceiver.attn.proj_out.weight": "perceiver_proj_out.weight",
+    "cond_enc.perceiver.attn.proj_out.bias": "perceiver_proj_out.bias",
+    "cond_enc.perceiver.attn.norm.weight": "perceiver_norm.weight",
+    "cond_enc.perceiver.attn.norm.bias": "perceiver_norm.bias",
+})
+
+
+def convert(ckpt_path: str, output_path: str):
+    print(f"Loading safetensors from {ckpt_path}")
+    sd = load_file(ckpt_path)
+
+    out = {}
+    for pt_key, pt_weight in sd.items():
+        if pt_key in KEY_MAP:
+            mlx_key = KEY_MAP[pt_key]
+            out[mlx_key] = mx.array(pt_weight.numpy())
+        elif pt_key.startswith("tfmr.layers."):
+            if not any(k in pt_key for k in ["rotary", "embed_tokens"]):
+                print(f"  WARNING: unmapped backbone key: {pt_key}")
+        elif pt_key == "tfmr.embed_tokens.weight":
+            pass
+        else:
+            print(f"  WARNING: unmapped key: {pt_key}")
+
+    print(f"Converted {len(out)} weight tensors")
+    print(f"Writing to {output_path}")
+    mx.savez(output_path, **out)
+    file_size = os.path.getsize(output_path)
+    print(f"Saved: {file_size / 1024 / 1024:.1f} MB")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        ckpt_dir = os.path.expanduser("~/.cache/huggingface/hub/models--ResembleAI--chatterbox/snapshots/")
+        snapshots = sorted(os.listdir(ckpt_dir))
+        if snapshots:
+            ckpt_path = os.path.join(ckpt_dir, snapshots[-1], "t3_cfg.safetensors")
+        else:
+            print("No cached model found. Download it first.")
+            sys.exit(1)
+    else:
+        ckpt_path = sys.argv[1]
+
+    output = sys.argv[2] if len(sys.argv) > 2 else "assets/t3_mlx_weights.npz"
+
+    if not os.path.exists(ckpt_path):
+        print(f"Checkpoint not found: {ckpt_path}")
+        sys.exit(1)
+
+    convert(ckpt_path, output)

--- a/scripts/poc_end_to_end.py
+++ b/scripts/poc_end_to_end.py
@@ -1,0 +1,107 @@
+"""End-to-end PoC: PyTorch cond + MLX T3 generate + S3Gen decode."""
+import sys, os
+import numpy as np
+import torch
+import mlx.core as mx
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+from chatterbox.models.t3.t3 import T3, T3Config
+from chatterbox.models.t3.modules.cond_enc import T3Cond
+from chatterbox.models.s3gen import S3Gen
+from safetensors.torch import load_file
+from chatterbox.models.tokenizers import EnTokenizer
+from chatterbox.models.t3_mlx import T3MLX, T3MLXConfig, _BACKBONE_KEYS
+
+CACHE = os.path.expanduser(
+    "~/.cache/huggingface/hub/models--ResembleAI--chatterbox/snapshots/5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18"
+)
+CKPT = os.path.join(CACHE, "t3_cfg.safetensors")
+
+
+def load_pt_t3(device="cpu"):
+    hp = T3Config.english_only()
+    model = T3(hp).to(device).eval()
+    sd = load_file(CKPT)
+    tfmr_sd = {k[5:]: v for k, v in sd.items() if k.startswith("tfmr.") and "embed_tokens" not in k}
+    model.tfmr.load_state_dict(tfmr_sd, strict=False)
+    model.speech_emb.load_state_dict({"weight": sd["speech_emb.weight"]})
+    model.speech_head.load_state_dict({"weight": sd["speech_head.weight"]})
+    model.text_emb.load_state_dict({"weight": sd["text_emb.weight"]})
+    model.text_head.load_state_dict({"weight": sd["text_head.weight"]})
+    model.text_pos_emb.load_state_dict({"emb.weight": sd["text_pos_emb.emb.weight"]})
+    model.speech_pos_emb.load_state_dict({"emb.weight": sd["speech_pos_emb.emb.weight"]})
+    cond_sd = {k[9:]: v for k, v in sd.items() if k.startswith("cond_enc.")}
+    model.cond_enc.load_state_dict(cond_sd, strict=False)
+    print("PyTorch T3 loaded")
+    return model
+
+
+def get_cond_emb(pt_model, spkr_emb_np, prompt_tokens_np, emotion_adv=0.5):
+    device = next(pt_model.parameters()).device
+    spkr_emb = torch.from_numpy(spkr_emb_np).to(device)
+    prompt_tokens = torch.from_numpy(prompt_tokens_np).long().to(device)
+    emotion = torch.tensor([[[emotion_adv]]], dtype=torch.float, device=device)
+    # Pass raw tokens, prepare_conditioning will embed + add position emb
+    t3_cond = T3Cond(
+        speaker_emb=spkr_emb,
+        cond_prompt_speech_tokens=prompt_tokens,
+        cond_prompt_speech_emb=None,
+        emotion_adv=emotion,
+    )
+    with torch.inference_mode():
+        cond_emb = pt_model.prepare_conditioning(t3_cond)
+    return cond_emb
+
+
+if __name__ == "__main__":
+    device = "cpu"
+    pt_model = load_pt_t3(device)
+    s3gen = S3Gen(meanflow=False).to(device).eval()
+    s3_sd = load_file(os.path.join(CACHE, "s3gen.safetensors"))
+    s3gen.load_state_dict(s3_sd, strict=False)
+    print("S3Gen loaded")
+
+    # Dummy conditioning for PoC (replace with real audio later)
+    rng = np.random.RandomState(42)
+    spkr_emb = rng.randn(1, 256).astype(np.float32)
+    prompt_tokens = rng.randint(0, 8194, size=(1, 150)).astype(np.int64)
+    cond_emb = get_cond_emb(pt_model, spkr_emb, prompt_tokens)
+
+    # Tokenize text
+    text = "Hello, this is a test of the text to speech system."
+    tokenizer = EnTokenizer(os.path.join(CACHE, "tokenizer.json"))
+    toks = tokenizer.text_to_tokens(text).to(device)
+    sot = torch.tensor([[pt_model.hp.start_text_token]], device=device)
+    eot = torch.tensor([[pt_model.hp.stop_text_token]], device=device)
+    text_tokens = torch.cat([sot, toks, eot], dim=1)
+    print(f"Text: '{text}' -> {text_tokens.shape[1]} tokens")
+
+    # MLX generate
+    cfg = T3MLXConfig()
+    mlx_model = T3MLX(cfg)
+    w = mx.load("assets/t3_mlx_weights.npz")
+    backbone = [(k, v) for k, v in w.items() if k in _BACKBONE_KEYS]
+    mlx_model.load_weights(backbone)
+    print("MLX T3 loaded")
+
+    speech_tokens_mx = mlx_model.generate(
+        mx.array(cond_emb.cpu().numpy()),
+        mx.array(text_tokens.cpu().numpy(), dtype=mx.int32),
+        max_new_tokens=500, seed=42,
+    )
+    print(f"Generated {len(speech_tokens_mx)} tokens")
+
+    # S3Gen decode
+    speech_tokens_pt = torch.from_numpy(np.array(speech_tokens_mx)).long().to(device)[None]
+
+    # Dummy reference for S3Gen
+    ref_wav = torch.zeros(1, 24000 * 10)
+    with torch.inference_mode():
+        wav, _ = s3gen.inference(speech_tokens=speech_tokens_pt, ref_wav=ref_wav, ref_sr=24000)
+
+    import soundfile as sf
+    out_path = "output_poc_mlx.wav"
+    sf.write(out_path, wav[0].cpu().numpy(), 24000)
+    print(f"Saved {out_path} ({len(wav[0]) / 24000:.1f}s)")

--- a/scripts/poc_mlx.py
+++ b/scripts/poc_mlx.py
@@ -1,0 +1,57 @@
+"""PoC: load T3MLX weights, run forward pass, measure tok/s."""
+import time
+import numpy as np
+import mlx.core as mx
+from src.chatterbox.models.t3_mlx import T3MLX, T3MLXConfig
+
+
+def load_weights(model, path="assets/t3_mlx_weights.npz"):
+    w = mx.load(path)
+    model.load_weights(list(w.items()))
+    n_loaded = len(w)
+    print(f"Loaded {n_loaded} weight tensors")
+
+
+def benchmark_forward(model, seq_len=100, n_warmup=3, n_iter=20):
+    B = 1
+    inputs_embeds = mx.random.normal((B, seq_len, model.config.dim), dtype=mx.float32)
+    print(f"Input shape: {inputs_embeds.shape}")
+
+    for _ in range(n_warmup):
+        logits, kvs = model.forward(inputs_embeds)
+
+    start = time.perf_counter()
+    for _ in range(n_iter):
+        logits, kvs = model.forward(inputs_embeds)
+    end = time.perf_counter()
+
+    avg_ms = (end - start) / n_iter * 1000
+    print(f"Forward ({seq_len} tokens): {avg_ms:.1f} ms | {1000/avg_ms:.0f} tok/s")
+
+    B = 1
+    inputs_embeds = mx.random.normal((B, 1, model.config.dim), dtype=mx.float32)
+    _, kvs = model.forward(mx.random.normal((B, seq_len, model.config.dim)))
+    for _ in range(n_warmup):
+        logits, kvs = model.forward(inputs_embeds, past_kvs=kvs)
+
+    start = time.perf_counter()
+    for _ in range(n_iter):
+        logits, kvs = model.forward(inputs_embeds, past_kvs=kvs)
+    end = time.perf_counter()
+
+    avg_ms_step = (end - start) / n_iter * 1000
+    print(f"Autoregressive step (1 token): {avg_ms_step:.1f} ms | {1000/avg_ms_step:.0f} tok/s")
+
+
+def benchmark_ar_loop(model, cond_len=34, text_len=50, n_tokens=200):
+    B = 1
+    cond_emb = mx.random.normal((B, cond_len, model.config.dim))
+    text_tokens = mx.random.randint(0, model.config.text_vocab_size, (B, text_len))
+
+    start = time.perf_counter()
+    tokens = model.generate(cond_emb, text_tokens, max_new_tokens=n_tokens, seed=0)
+    elapsed = time.perf_counter() - start
+
+    n_gen = tokens.shape[0]
+    print(f"Generated {n_gen} tokens in {elapsed:.2f}s = {n_gen/elapsed:.1f} tok/s")
+    return tokens

--- a/src/chatterbox/models/t3_mlx.py
+++ b/src/chatterbox/models/t3_mlx.py
@@ -1,0 +1,222 @@
+import math
+import mlx.core as mx
+import mlx.nn as nn
+
+_BACKBONE_KEYS = {f"layers.{i}.{sub}" for i in range(30) for sub in [
+    "attention_norm.weight",
+    "ffn_norm.weight",
+    "attention.q_proj.weight", "attention.k_proj.weight",
+    "attention.v_proj.weight", "attention.o_proj.weight",
+    "mlp.gate.weight", "mlp.up.weight", "mlp.down.weight",
+]} | {"norm.weight",     "speech_emb.weight", "speech_head.weight",
+    "text_emb.weight", "text_head.weight",
+    "speech_pos_emb.weight", "text_pos_emb.weight"}
+
+
+def llama3_rope_freqs(dim, base=500000.0, original_max_pos=8192,
+                      scaling_factor=8.0, high_freq_factor=4.0, low_freq_factor=1.0):
+    indices = mx.arange(0, dim, 2, dtype=mx.float32)
+    inv_freq = 1.0 / (base ** (indices / dim))
+
+    low_wavelen = original_max_pos / low_freq_factor
+    high_wavelen = original_max_pos / high_freq_factor
+    wavelen = 2.0 * math.pi / inv_freq
+    smooth = (wavelen - high_wavelen) / (low_wavelen - high_wavelen)
+    smooth = mx.clip(smooth, 0.0, 1.0)
+
+    scaled = (1.0 - smooth) * (inv_freq / scaling_factor) + smooth * inv_freq
+    return scaled
+
+
+_ROPE_FREQS = llama3_rope_freqs(64)
+
+
+class Attention(nn.Module):
+    def __init__(self, dim: int, n_heads: int, bias: bool = False):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = dim // n_heads
+        self.q_proj = nn.Linear(dim, dim, bias=bias)
+        self.k_proj = nn.Linear(dim, dim, bias=bias)
+        self.v_proj = nn.Linear(dim, dim, bias=bias)
+        self.o_proj = nn.Linear(dim, dim, bias=bias)
+
+    def __call__(self, x, mask=None, past_kv=None):
+        B, L, D = x.shape
+        q = self.q_proj(x).reshape(B, L, self.n_heads, self.head_dim).transpose(0, 2, 1, 3)
+        k = self.k_proj(x).reshape(B, L, self.n_heads, self.head_dim).transpose(0, 2, 1, 3)
+        v = self.v_proj(x).reshape(B, L, self.n_heads, self.head_dim).transpose(0, 2, 1, 3)
+
+        if past_kv is not None:
+            pk, pv = past_kv
+            cache_len = pk.shape[2]
+            q = mx.fast.rope(q, dims=self.head_dim, traditional=False,
+                             base=None, scale=1.0, offset=cache_len, freqs=_ROPE_FREQS)
+            k = mx.fast.rope(k, dims=self.head_dim, traditional=False,
+                             base=None, scale=1.0, offset=cache_len, freqs=_ROPE_FREQS)
+            k = mx.concatenate([pk, k], axis=2)
+            v = mx.concatenate([pv, v], axis=2)
+        else:
+            q = mx.fast.rope(q, dims=self.head_dim, traditional=False,
+                             base=None, scale=1.0, offset=0, freqs=_ROPE_FREQS)
+            k = mx.fast.rope(k, dims=self.head_dim, traditional=False,
+                             base=None, scale=1.0, offset=0, freqs=_ROPE_FREQS)
+
+        scale = 1.0 / math.sqrt(self.head_dim)
+        out = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, mask=mask)
+        out = out.transpose(0, 2, 1, 3).reshape(B, L, D)
+        out = self.o_proj(out)
+        return out, (k, v)
+
+
+class SwiGLU(nn.Module):
+    def __init__(self, dim: int, hidden_dim: int, bias: bool = False):
+        super().__init__()
+        self.gate = nn.Linear(dim, hidden_dim, bias=bias)
+        self.up = nn.Linear(dim, hidden_dim, bias=bias)
+        self.down = nn.Linear(hidden_dim, dim, bias=bias)
+
+    def __call__(self, x):
+        return self.down(nn.silu(self.gate(x)) * self.up(x))
+
+
+class LLaMADecoderLayer(nn.Module):
+    def __init__(self, dim: int, n_heads: int, mlp_ratio: int = 4):
+        super().__init__()
+        self.attention_norm = nn.RMSNorm(dim)
+        self.attention = Attention(dim, n_heads)
+        self.ffn_norm = nn.RMSNorm(dim)
+        self.mlp = SwiGLU(dim, dim * mlp_ratio)
+
+    def __call__(self, x, mask=None, past_kv=None):
+        r = x
+        x = self.attention_norm(x)
+        x, kv = self.attention(x, mask=mask, past_kv=past_kv)
+        x = r + x
+
+        r = x
+        x = self.ffn_norm(x)
+        x = self.mlp(x)
+        x = r + x
+        return x, kv
+
+
+class T3MLXConfig:
+    dim = 1024
+    n_layers = 30
+    n_heads = 16
+    mlp_ratio = 4
+    vocab_size = 8194
+    text_vocab_size = 704
+    max_text_tokens = 2048
+    max_speech_tokens = 4096
+    text_pos_len = max_text_tokens + 2
+    speech_pos_len = max_speech_tokens + 4
+    start_speech_token = 6561
+    stop_speech_token = 6562
+
+
+class T3MLX(nn.Module):
+    def __init__(self, config: T3MLXConfig = None):
+        super().__init__()
+        self.config = config or T3MLXConfig()
+        cfg = self.config
+
+        self.text_emb = nn.Embedding(cfg.text_vocab_size, cfg.dim)
+        self.speech_emb = nn.Embedding(cfg.vocab_size, cfg.dim)
+        self.text_pos_emb = nn.Embedding(cfg.text_pos_len, cfg.dim)
+        self.speech_pos_emb = nn.Embedding(cfg.speech_pos_len, cfg.dim)
+        self.text_head = nn.Linear(cfg.dim, cfg.text_vocab_size, bias=False)
+        self.speech_head = nn.Linear(cfg.dim, cfg.vocab_size, bias=False)
+
+        self.layers = [LLaMADecoderLayer(cfg.dim, cfg.n_heads, cfg.mlp_ratio) for _ in range(cfg.n_layers)]
+        self.norm = nn.RMSNorm(cfg.dim)
+
+    def embed_text(self, text_tokens):
+        emb = self.text_emb(text_tokens)
+        n = text_tokens.shape[1]
+        pos = self.text_pos_emb(mx.arange(n, dtype=mx.int64))
+        return emb + pos
+
+    def embed_speech(self, speech_tokens):
+        return self.speech_emb(speech_tokens)
+
+    def embed_speech_with_pos(self, speech_tokens):
+        emb = self.speech_emb(speech_tokens)
+        n = speech_tokens.shape[1]
+        pos = self.speech_pos_emb(mx.arange(n, dtype=mx.int64))
+        return emb + pos
+
+    def forward(self, inputs_embeds, past_kvs=None):
+        h = inputs_embeds
+        new_kvs = []
+        for i, layer in enumerate(self.layers):
+            pkv = past_kvs[i] if past_kvs is not None else None
+            h, kv = layer(h, mask=None, past_kv=pkv)
+            new_kvs.append(kv)
+        h = self.norm(h)
+        logits = self.speech_head(h)
+        return logits, new_kvs
+
+    def generate(
+        self,
+        cond_emb,
+        text_tokens,
+        max_new_tokens=500,
+        temperature=0.8,
+        top_p=0.95,
+        repetition_penalty=1.2,
+        seed=42,
+    ):
+        mx.random.seed(seed)
+
+        text_emb = self.embed_text(text_tokens)
+
+        bos_token = mx.array([[self.config.start_speech_token]], dtype=mx.int32)
+        speech_emb = self.embed_speech_with_pos(bos_token)
+
+        inputs_embeds = mx.concatenate([cond_emb, text_emb, speech_emb], axis=1)
+
+        logits, past_kvs = self.forward(inputs_embeds, past_kvs=None)
+        logits = logits[:, -1, :].squeeze(0)
+
+        generated_ids = []
+
+        for step in range(max_new_tokens):
+            logits = self._sample_logits(logits, temperature, top_p, repetition_penalty, generated_ids)
+            probs = mx.softmax(logits, axis=-1)
+            next_token = self._top_p_sample(probs, top_p)
+            token_id = next_token.item()
+            if token_id == self.config.stop_speech_token:
+                break
+            generated_ids.append(token_id)
+            token = next_token.reshape(1, 1)
+
+            token_emb = self.embed_speech(token)
+            logits, past_kvs = self.forward(token_emb, past_kvs=past_kvs)
+            logits = logits[:, -1, :].squeeze(0)
+
+        return mx.array(generated_ids, dtype=mx.int64)
+
+    @staticmethod
+    def _sample_logits(logits, temperature, top_p, repetition_penalty, generated_ids):
+        logits = logits / temperature
+        if repetition_penalty != 1.0 and generated_ids:
+            for tid in set(generated_ids):
+                if logits[tid] < 0:
+                    logits[tid] *= repetition_penalty
+                else:
+                    logits[tid] /= repetition_penalty
+        return logits
+
+    @staticmethod
+    def _top_p_sample(probs, top_p):
+        sorted_indices = mx.argsort(probs)[::-1]
+        sorted_probs = probs[sorted_indices]
+        cumsum = mx.cumsum(sorted_probs, axis=-1)
+        cutoff = mx.argmax(cumsum >= top_p).item()
+        cutoff = max(0, cutoff)
+        cutoff_indices = sorted_indices[:cutoff + 1]
+        cutoff_probs = sorted_probs[:cutoff + 1] / mx.sum(sorted_probs[:cutoff + 1])
+        sample = mx.random.categorical(mx.log(cutoff_probs + 1e-10), shape=(1,))
+        return mx.array([cutoff_indices[sample.item()]], dtype=mx.int32)

--- a/src/chatterbox/models/t3_mlx.py
+++ b/src/chatterbox/models/t3_mlx.py
@@ -141,18 +141,18 @@ class T3MLX(nn.Module):
     def embed_speech(self, speech_tokens):
         return self.speech_emb(speech_tokens)
 
-    def embed_speech_with_pos(self, speech_tokens):
+    def embed_speech_with_pos(self, speech_tokens, offset=0):
         emb = self.speech_emb(speech_tokens)
         n = speech_tokens.shape[1]
-        pos = self.speech_pos_emb(mx.arange(n, dtype=mx.int64))
+        pos = self.speech_pos_emb(mx.arange(offset, offset + n, dtype=mx.int64))
         return emb + pos
 
-    def forward(self, inputs_embeds, past_kvs=None):
+    def forward(self, inputs_embeds, past_kvs=None, mask=None):
         h = inputs_embeds
         new_kvs = []
         for i, layer in enumerate(self.layers):
             pkv = past_kvs[i] if past_kvs is not None else None
-            h, kv = layer(h, mask=None, past_kv=pkv)
+            h, kv = layer(h, mask=mask, past_kv=pkv)
             new_kvs.append(kv)
         h = self.norm(h)
         logits = self.speech_head(h)
@@ -177,13 +177,15 @@ class T3MLX(nn.Module):
 
         inputs_embeds = mx.concatenate([cond_emb, text_emb, speech_emb], axis=1)
 
-        logits, past_kvs = self.forward(inputs_embeds, past_kvs=None)
+        L = inputs_embeds.shape[1]
+        causal_mask = mx.tril(mx.ones((L, L), dtype=mx.bool_))
+        logits, past_kvs = self.forward(inputs_embeds, past_kvs=None, mask=causal_mask)
         logits = logits[:, -1, :].squeeze(0)
 
         generated_ids = []
 
         for step in range(max_new_tokens):
-            logits = self._sample_logits(logits, temperature, top_p, repetition_penalty, generated_ids)
+            logits = self._sample_logits(logits, temperature, repetition_penalty, generated_ids)
             probs = mx.softmax(logits, axis=-1)
             next_token = self._top_p_sample(probs, top_p)
             token_id = next_token.item()
@@ -192,14 +194,16 @@ class T3MLX(nn.Module):
             generated_ids.append(token_id)
             token = next_token.reshape(1, 1)
 
-            token_emb = self.embed_speech(token)
-            logits, past_kvs = self.forward(token_emb, past_kvs=past_kvs)
+            token_emb = self.embed_speech_with_pos(token, offset=step + 1)
+            logits, past_kvs = self.forward(token_emb, past_kvs=past_kvs, mask=None)
             logits = logits[:, -1, :].squeeze(0)
 
         return mx.array(generated_ids, dtype=mx.int64)
 
     @staticmethod
-    def _sample_logits(logits, temperature, top_p, repetition_penalty, generated_ids):
+    def _sample_logits(logits, temperature, repetition_penalty, generated_ids):
+        if temperature <= 1e-6:
+            temperature = 1e-6
         logits = logits / temperature
         if repetition_penalty != 1.0 and generated_ids:
             for tid in set(generated_ids):
@@ -217,6 +221,7 @@ class T3MLX(nn.Module):
         cutoff = mx.argmax(cumsum >= top_p).item()
         cutoff = max(0, cutoff)
         cutoff_indices = sorted_indices[:cutoff + 1]
-        cutoff_probs = sorted_probs[:cutoff + 1] / mx.sum(sorted_probs[:cutoff + 1])
+        cutoff_sum = mx.sum(sorted_probs[:cutoff + 1])
+        cutoff_probs = sorted_probs[:cutoff + 1] / (cutoff_sum + 1e-10)
         sample = mx.random.categorical(mx.log(cutoff_probs + 1e-10), shape=(1,))
         return mx.array([cutoff_indices[sample.item()]], dtype=mx.int32)


### PR DESCRIPTION
This pull request introduces the initial proof-of-concept (PoC) for porting the T3 text-to-speech model's backbone to MLX, Apple's Metal-native ML framework. It establishes the technical boundary between PyTorch and MLX, provides scripts for weight conversion and benchmarking, and documents architectural decisions and success criteria. The changes focus on enabling fast, real-time inference on Apple Silicon, while keeping peripheral components in PyTorch for simplicity.

**Key changes:**

### MLX Port Architecture and Documentation

- Added a comprehensive domain context (`CONTEXT.md`) and five architectural decision records (ADRs) detailing the MLX port boundary, backbone construction, weight conversion, PoC scope, and success criteria. These documents clarify what is ported, the rationale, and how success is measured. [[1]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14R1-R24) [[2]](diffhunk://#diff-f08aed076215cecd03fd91c9c936ae718194152d0a23ca93553456fc2f529015R1-R32) [[3]](diffhunk://#diff-529e02dca3ae4b578fce81d1c2ec51debd590da5285a555d09f9f4d13d64e687R1-R28) [[4]](diffhunk://#diff-0e2c5a1dce2b1ad333aa184d5587c4ffb6c2b5dd09cc22bab6d770b8524c467fR1-R42) [[5]](diffhunk://#diff-a943993428423fc0c5fbf312e59d80bbc288bbf395c8d72956c3006d50f01b74R1-R29) [[6]](diffhunk://#diff-1ebab1730c854b291fff33aa633cb5f5ed6ca2c41d6aed8659f5147045643b8aR1-R21)

### Weight Conversion and Loading

- Introduced `scripts/convert_weights_mlx.py`, a script to convert T3 model weights from HuggingFace safetensors format to MLX-compatible `.npz` files, with explicit key mapping for all backbone and embedding layers.

### MLX Inference and Benchmarking

- Added `scripts/poc_mlx.py` for benchmarking the MLX T3 backbone, measuring forward pass and autoregressive generation speed, and verifying correct weight loading.
- Added `scripts/poc_end_to_end.py` for an end-to-end PoC that runs PyTorch-based conditioning, MLX-based T3 generation, and PyTorch S3Gen audio decoding, demonstrating the cross-framework pipeline.

### Dependency Management

- Updated `pyproject.toml` to add MLX as an optional dependency, enabling easy installation for users with Apple Silicon.

---

**References:**  
[[1]](diffhunk://#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14R1-R24) [[2]](diffhunk://#diff-f08aed076215cecd03fd91c9c936ae718194152d0a23ca93553456fc2f529015R1-R32) [[3]](diffhunk://#diff-529e02dca3ae4b578fce81d1c2ec51debd590da5285a555d09f9f4d13d64e687R1-R28) [[4]](diffhunk://#diff-0e2c5a1dce2b1ad333aa184d5587c4ffb6c2b5dd09cc22bab6d770b8524c467fR1-R42) [[5]](diffhunk://#diff-a943993428423fc0c5fbf312e59d80bbc288bbf395c8d72956c3006d50f01b74R1-R29) [[6]](diffhunk://#diff-1ebab1730c854b291fff33aa633cb5f5ed6ca2c41d6aed8659f5147045643b8aR1-R21) [[7]](diffhunk://#diff-8eb924043559267988e9204811fbcf9559ab0b0932cb2c6abf96dec585dc8655R1-R87) [[8]](diffhunk://#diff-0ffeea513121499e829bdfdd3f144c6f23800b58fe40624413d14dc4a6edaf02R1-R57) [[9]](diffhunk://#diff-58688ecebe1d508ab7d3a9f56a9faa3a1a000402cbf64448fb7995a2443d8973R1-R107) [[10]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R34-R36)